### PR TITLE
지도 content타입에 따른 필터링 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@tanstack/react-query-devtools": "^5.80.6",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.15.29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.28.0
+      '@tanstack/react-query-devtools':
+        specifier: ^5.80.6
+        version: 5.80.6(@tanstack/react-query@5.79.0(react@19.1.0))(react@19.1.0)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -624,6 +627,15 @@ packages:
 
   '@tanstack/query-core@5.79.0':
     resolution: {integrity: sha512-s+epTqqLM0/TbJzMAK7OEhZIzh63P9sWz5HEFc5XHL4FvKQXQkcjI8F3nee+H/xVVn7mrP610nVXwOytTSYd0w==}
+
+  '@tanstack/query-devtools@5.80.0':
+    resolution: {integrity: sha512-D6gH4asyjaoXrCOt5vG5Og/YSj0D/TxwNQgtLJIgWbhbWCC/emu2E92EFoVHh4ppVWg1qT2gKHvKyQBEFZhCuA==}
+
+  '@tanstack/react-query-devtools@5.80.6':
+    resolution: {integrity: sha512-y7Es0OJ4RYQxrPYsuuQP0jxjgJ40a03UbEPmJ6vwf/ERVMRoRIMkpjtvPxf1D+n9nwPfWmGdD0jW8Wxd+TxeEw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.80.6
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.79.0':
     resolution: {integrity: sha512-DjC4JIYZnYzxaTzbg3osOU63VNLP67dOrWet2cZvXgmgwAXNxfS52AMq86M5++ILuzW+BqTUEVMTjhrZ7/XBuA==}
@@ -2021,6 +2033,14 @@ snapshots:
       vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@tanstack/query-core@5.79.0': {}
+
+  '@tanstack/query-devtools@5.80.0': {}
+
+  '@tanstack/react-query-devtools@5.80.6(@tanstack/react-query@5.79.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.80.0
+      '@tanstack/react-query': 5.79.0(react@19.1.0)
+      react: 19.1.0
 
   '@tanstack/react-query@5.79.0(react@19.1.0)':
     dependencies:

--- a/src/config/QueryProvider.tsx
+++ b/src/config/QueryProvider.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,6 +17,9 @@ const queryClient = new QueryClient({
 });
 export default function QueryProvider({ children }: PropsWithChildren) {
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      {children}
+    </QueryClientProvider>
   );
 }

--- a/src/pages/geoMap/components/GeoAroundTouristMap.tsx
+++ b/src/pages/geoMap/components/GeoAroundTouristMap.tsx
@@ -1,29 +1,33 @@
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
-import { useState } from 'react';
 import AroundTouristNavigate from './AroundTouristNavigate';
 import CurrentDeviceLocation from './CurrentDeviceLocation';
 import { markerImageMap } from '@/pages/const/MARKER';
-import type { TourItem } from '@/pages/types';
+import useAroundTouristQuery from '../service/getAroundTouristMapData';
+import type { AroundContentTypeId } from '../types';
+import { useState } from 'react';
 
 const destination = {
-  lat: 37.629362,
-  lng: 127.095991,
+  latitude: 37.629362,
+  longitude: 127.095991,
 };
 
 export default function GeoAroundTouristMap() {
-  const [aroundTouristObjects, setAroundTouristObjects] =
-    useState<TourItem[]>();
+  const [selectedContentTypeId, setSelectedContentTypeId] =
+    useState<AroundContentTypeId>('12');
+  const { aroundTouristObjects, setAroundTouristObjects } =
+    useAroundTouristQuery(destination, selectedContentTypeId);
 
   return (
     <Map
       center={{
-        lat: destination.lat,
-        lng: destination.lng,
+        lat: destination.latitude,
+        lng: destination.longitude,
       }}
       className="w-full h-full"
       level={7}
     >
       <AroundTouristNavigate
+        setSelectedContentTypeId={setSelectedContentTypeId}
         setAroundTouristObjects={setAroundTouristObjects}
       />
 
@@ -48,7 +52,7 @@ export default function GeoAroundTouristMap() {
       })}
       <MapMarker
         zIndex={999}
-        position={{ lat: destination.lat, lng: destination.lng }}
+        position={{ lat: destination.latitude, lng: destination.longitude }}
       >
         관광지
       </MapMarker>

--- a/src/pages/geoMap/components/GeoAroundTouristMap.tsx
+++ b/src/pages/geoMap/components/GeoAroundTouristMap.tsx
@@ -1,6 +1,5 @@
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { useState } from 'react';
-import type { MarkerType } from '../types';
 import AroundTouristNavigate from './AroundTouristNavigate';
 import CurrentDeviceLocation from './CurrentDeviceLocation';
 import { markerImageMap } from '@/pages/const/MARKER';
@@ -15,10 +14,6 @@ export default function GeoAroundTouristMap() {
   const [aroundTouristObjects, setAroundTouristObjects] =
     useState<TourItem[]>();
 
-  const [contentTypeIdGroup, setContentTypeIdGroup] = useState<MarkerType[]>([
-    { contentTypeId: '12', imageSrc: markerImageMap['12'], altText: '관광지' },
-  ]);
-
   return (
     <Map
       center={{
@@ -28,7 +23,9 @@ export default function GeoAroundTouristMap() {
       className="w-full h-full"
       level={7}
     >
-      <AroundTouristNavigate contentTypeIdGroup={contentTypeIdGroup} />
+      <AroundTouristNavigate
+        setAroundTouristObjects={setAroundTouristObjects}
+      />
 
       <CurrentDeviceLocation />
       {aroundTouristObjects?.map(tourist => {

--- a/src/pages/geoMap/lib/transportation/getPolyLinesCarPathInfo.ts
+++ b/src/pages/geoMap/lib/transportation/getPolyLinesCarPathInfo.ts
@@ -1,4 +1,4 @@
-import { TRAFFIC } from '@/const/TMAP';
+import { TRAFFIC } from '@/pages/const/TMAP';
 import type { CarResponse } from '../../types';
 
 const getCoordinatesPointLines = (coords: number[][]) => {

--- a/src/pages/geoMap/service/getAroundTouristMapData.ts
+++ b/src/pages/geoMap/service/getAroundTouristMapData.ts
@@ -28,7 +28,7 @@ const getAroundTouristMapData = async ({
       mapX: location.longitude,
       mapY: location.latitude,
       arrange: 'E',
-      radius: '5000',
+      radius: '3000',
       numOfRows: 30,
       contentTypeId,
       pageNo: 1,
@@ -38,22 +38,12 @@ const getAroundTouristMapData = async ({
   return response.data.response.body;
 };
 
-const useAroundTouristMapMutation = ({
-  location,
-  contentTypeId,
-}: LocationBasedItemRequest) => {
+const useAroundTouristMapMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: getAroundTouristMapData,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [
-          'aroundTouristMapData',
-          location?.latitude,
-          location?.longitude,
-          contentTypeId,
-        ],
-      });
+    onSuccess: data => {
+      queryClient.setQueryData(['aroundTouristMapData'], data.items.item);
     },
     onError: error => {
       console.error('맵 데이터 가져오기 실패', error);


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->
#18 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
![image](https://github.com/user-attachments/assets/637275d3-6a72-4e30-939f-7d3ba13bb6c5)

### 1차 시도
- Mutation을 활용해서 버튼을 누를 때 마다 요청을 보내서 필터링을 유지
- 문제점: 캐싱을 하지 못해서 매 번 요청이 들어감

### 2차 시도
- query로 변경 -> query Key가 바뀌면 값이 새롭게 로드 되는 기능을 활용해서 query를 불러오면서 누적 처리
- remove를 통해서는 기존 state로 저장된 값만 삭제
- 문제점: remove를 통해서 값을 삭제한 직후, key 값이 동일하기 때문에 캐싱된 정보를 불러오지 못함 -> 다른 contentTypeId를 눌렀다가 다시 눌러야 정상적으로 캐싱된 데이터를 불러옴

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)

- 제가 위에 1차, 2차 시도라 적어 놨는데, 해당 부분을 확인해 주시고, 솔루션좀 주셨으면 좋겠습니다.
- 플로우는 다음과 같습니다
```
1. 페이지에 접속시 `useAroundTouristQuery` 를 통해서 `open API`를 호출합니다. 이 때 `destination(목적지)`과 `selectedContentTypeId: 12(관광지)`를 넘깁니다. 
2. 해당 훅 내부에는 `state`를 선언해서, 현재 값과 이전 값들의 누적된 배열을 저장합니다. 
3. return 값으론 누적된 데이터의 getter와 setter 함수를 넘깁니다.
4. `AroundTouristNavigate` 컴포넌트로 props로 전달해서 `TypeId`값을 바꿉니다. -> fetch 발생
5. 새로운 데이터가 누적되어 화면에 표출됩니다.
6. `removeMakerFilter`.함수를 통해서 누적된 값 중 삭제된 값을 제거합니다.
7. [문제 발생] -> 여기서 다시 동일한 `TypeId`를 선택시 이전 `TypeId`와 동일해서 `fetch`가 발생하지 않습니다.
```