### PR TITLE
geoAround geoDestination 폴더 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
     "eslint-plugin-tailwindcss": "^3.18.0",
+    "framer-motion": "^12.16.0",
+    "motion": "^12.16.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-kakao-maps-sdk": "^1.1.27",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.18.0
         version: 3.18.0(tailwindcss@4.1.8)
+      framer-motion:
+        specifier: ^12.16.0
+        version: 12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      motion:
+        specifier: ^12.16.0
+        version: 12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1072,6 +1078,20 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
+  framer-motion@12.16.0:
+    resolution: {integrity: sha512-xryrmD4jSBQrS2IkMdcTmiS4aSKckbS7kLDCuhUn9110SQKG1w3zlq1RTqCblewg+ZYe+m3sdtzQA6cRwo5g8Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1312,6 +1332,26 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  motion-dom@12.16.0:
+    resolution: {integrity: sha512-Z2nGwWrrdH4egLEtgYMCEN4V2qQt1qxlKy/uV7w691ztyA41Q5Rbn0KNGbsNVDZr9E8PD2IOQ3hSccRnB6xWzw==}
+
+  motion-utils@12.12.1:
+    resolution: {integrity: sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==}
+
+  motion@12.16.0:
+    resolution: {integrity: sha512-P3HA83fnPMEGBLfKdD5vDdjH1Aa3wM3jT3+HX3fCVpy/4/lJiqvABajLgZenBu+rzkFzmeaPkvT7ouf9Tq5tVQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1529,6 +1569,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2544,6 +2587,15 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
+  framer-motion@12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.16.0
+      motion-utils: 12.12.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   fsevents@2.3.3:
     optional: true
 
@@ -2732,6 +2784,20 @@ snapshots:
       minipass: 7.1.2
 
   mkdirp@3.0.1: {}
+
+  motion-dom@12.16.0:
+    dependencies:
+      motion-utils: 12.12.1
+
+  motion-utils@12.12.1: {}
+
+  motion@12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      framer-motion: 12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   ms@2.1.3: {}
 
@@ -2923,6 +2989,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/pages/geoMap/GeoMap.tsx
+++ b/src/pages/geoMap/GeoMap.tsx
@@ -1,6 +1,5 @@
 import { BackButton, MenuIcon } from '@/components';
-import GeoDestination from './components/GeoDestination';
-import GeoAroundTouristMap from './components/GeoAroundTouristMap';
+import { GeoAroundTouristMap, GeoDestinationNavigateMap } from './components';
 
 export default function GeoMap() {
   return (
@@ -13,7 +12,7 @@ export default function GeoMap() {
       <div className="flex-1">
         <div className="w-full h-full relative">
           <GeoAroundTouristMap />
-          {/* <GeoDestination /> */}
+          {/* <GeoDestinationNavigateMap /> */}
         </div>
       </div>
     </div>

--- a/src/pages/geoMap/components/GeoAroundTouristMap.tsx
+++ b/src/pages/geoMap/components/GeoAroundTouristMap.tsx
@@ -1,8 +1,8 @@
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
-import AroundTouristNavigate from './AroundTouristNavigate';
 import CurrentDeviceLocation from './CurrentDeviceLocation';
-import { markerImageMap } from '@/pages/const/MARKER';
 import { useGetAroundNavigate } from '../lib/aroundNavigate';
+import AroundTouristNavigate from './geoAroundTourist/AroundTouristNavigate';
+import NearbyTouristAttractionPinPoint from './geoAroundTourist/NearbyTouristAttractionPinpoint';
 
 const destination = {
   latitude: 37.629362,
@@ -34,22 +34,7 @@ export default function GeoAroundTouristMap() {
 
       <CurrentDeviceLocation />
       {aroundTouristObjects.map(tourist => {
-        return (
-          <MapMarker
-            key={tourist.contentid}
-            position={{
-              lat: tourist.mapy!,
-              lng: tourist.mapx!,
-            }}
-            image={{
-              src: markerImageMap[tourist.contenttypeid],
-              size: {
-                width: 38,
-                height: 50,
-              },
-            }}
-          ></MapMarker>
-        );
+        return <NearbyTouristAttractionPinPoint {...tourist} />;
       })}
       <MapMarker
         zIndex={999}

--- a/src/pages/geoMap/components/geoAroundTourist/AroundTouristNavigate.tsx
+++ b/src/pages/geoMap/components/geoAroundTourist/AroundTouristNavigate.tsx
@@ -1,9 +1,9 @@
 import { markerList } from '@/pages/const/MARKER';
-import type { AroundContentTypeId, MarkerType } from '../types';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { FreeMode } from 'swiper/modules';
+import type { AroundContentTypeId, MarkerType } from '../../types';
 
 interface AroundTouristNavigateProps {
   contentTypeIdGroup: MarkerType[];

--- a/src/pages/geoMap/components/geoAroundTourist/DetailsOfNearbyTouristAttractions.tsx
+++ b/src/pages/geoMap/components/geoAroundTourist/DetailsOfNearbyTouristAttractions.tsx
@@ -1,0 +1,13 @@
+import { AnimatePresence, motion } from 'motion/react';
+
+export default function DetailsOfNearbyTouristAttractions() {
+  return (
+    <div className="fixed bottom-0 left-0 w-full h-40 flex items-center justify-center z-(--z-layer5)">
+      <AnimatePresence>
+        <motion.div className="max-w-[375px] w-full h-full bg-black">
+          정보
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/pages/geoMap/components/geoAroundTourist/NearbyTouristAttractionPinpoint.tsx
+++ b/src/pages/geoMap/components/geoAroundTourist/NearbyTouristAttractionPinpoint.tsx
@@ -1,0 +1,34 @@
+import { markerImageMap } from '@/pages/const/MARKER';
+import type { TourItem } from '@/pages/types';
+import { useState } from 'react';
+import { MapMarker } from 'react-kakao-maps-sdk';
+import DetailsOfNearbyTouristAttractions from './DetailsOfNearbyTouristAttractions';
+
+type NearbyTouristAttractionPinPointProps = TourItem;
+
+export default function NearbyTouristAttractionPinPoint(
+  tourist: NearbyTouristAttractionPinPointProps
+) {
+  const [openAttractionDetail, setOpenAttractionDetail] = useState(false);
+
+  return (
+    <>
+      <MapMarker
+        key={tourist.contentid}
+        position={{
+          lat: tourist.mapy!,
+          lng: tourist.mapx!,
+        }}
+        image={{
+          src: markerImageMap[tourist.contenttypeid],
+          size: {
+            width: 38,
+            height: 50,
+          },
+        }}
+        onClick={() => setOpenAttractionDetail(prev => !prev)}
+      ></MapMarker>
+      {openAttractionDetail && <DetailsOfNearbyTouristAttractions />}
+    </>
+  );
+}

--- a/src/pages/geoMap/components/geoAroundTourist/index.ts
+++ b/src/pages/geoMap/components/geoAroundTourist/index.ts
@@ -1,0 +1,1 @@
+export { default as AroundTouristNavigate } from './AroundTouristNavigate';

--- a/src/pages/geoMap/components/index.ts
+++ b/src/pages/geoMap/components/index.ts
@@ -1,0 +1,4 @@
+export { default as GeoDestinationNavigateMap } from './GeoDestination';
+export { default as GeoAroundTouristMap } from './GeoAroundTouristMap';
+
+export * as geoAroundTourist from './geoAroundTourist';


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용

지도에서 사용하는
- 주변 관광지 검색
- 관광지 길찾기
두 기능을 폴더로 분리했습니다.

원래 detail부분을 작업하려고했는데, @rhehfl 님께서 `bottom Sheet`작업을 해주시면 그걸로 사용하기로 했습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
