### PR TITLE
filter bar 생성

### DIFF
--- a/src/components/TourTypeBadge.tsx
+++ b/src/components/TourTypeBadge.tsx
@@ -1,5 +1,6 @@
 import { TOUR_TYPE } from '@/pages/const/MARKER';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import type { AroundContentTypeId } from '@/pages/types';
+
 interface TourTypeBadgeProps {
   contenttypeid: AroundContentTypeId;
   className?: string;

--- a/src/components/TouristContentsTypeFilter.tsx
+++ b/src/components/TouristContentsTypeFilter.tsx
@@ -1,0 +1,3 @@
+export default function TouristContentsTypeFilter() {
+  return <div></div>;
+}

--- a/src/components/TouristContentsTypeFilter.tsx
+++ b/src/components/TouristContentsTypeFilter.tsx
@@ -1,5 +1,5 @@
 import { markerList } from '@/pages/const/MARKER';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import type { AroundContentTypeId } from '@/pages/types';
 import clsx from 'clsx';
 import { useCallback } from 'react';
 import { FreeMode } from 'swiper/modules';

--- a/src/components/TouristContentsTypeFilter.tsx
+++ b/src/components/TouristContentsTypeFilter.tsx
@@ -1,3 +1,46 @@
-export default function TouristContentsTypeFilter() {
-  return <div></div>;
+import { markerList } from '@/pages/const/MARKER';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import clsx from 'clsx';
+import { useCallback } from 'react';
+import { FreeMode } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+interface TouristContentsTypeFilterProps {
+  contentTypeId: AroundContentTypeId;
+  setContentTypeId: React.Dispatch<React.SetStateAction<AroundContentTypeId>>;
+}
+export default function TouristContentsTypeFilter({
+  contentTypeId,
+  setContentTypeId,
+}: TouristContentsTypeFilterProps) {
+  const getButtonClass = useCallback((isActive: boolean) => {
+    return clsx(
+      'px-2.5 py-[6px] flex items-center justify-center rounded-2xl border-primary-dark border-2 cursor-pointer',
+      {
+        'bg-primary-red text-primary-dark border-secondary-red': isActive,
+      }
+    );
+  }, []);
+
+  return (
+    <Swiper
+      slidesPerView="auto"
+      spaceBetween={5}
+      freeMode={true}
+      direction="horizontal"
+      modules={[FreeMode]}
+      className="cursor-grab"
+    >
+      {markerList.map(marker => (
+        <SwiperSlide className=" !w-auto " key={marker.contentTypeId}>
+          <button
+            className={getButtonClass(contentTypeId === marker.contentTypeId)}
+            onClick={() => setContentTypeId(marker.contentTypeId)}
+          >
+            <span className="text-xs">{marker.altText}</span>
+          </button>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
 }

--- a/src/components/TouristContentsTypeFilter.tsx
+++ b/src/components/TouristContentsTypeFilter.tsx
@@ -17,7 +17,7 @@ export default function TouristContentsTypeFilter({
     return clsx(
       'px-2.5 py-[6px] flex items-center justify-center rounded-2xl border-primary-dark border-2 cursor-pointer',
       {
-        'bg-primary-red text-primary-dark border-secondary-red': isActive,
+        'bg-primary-red text-white border-secondary-red': isActive,
       }
     );
   }, []);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as LoadingSpinner } from './LoadingSpinner';
 export { default as TourCard } from './TourCard';
 export { default as DistanceTimeInfo } from './DistanceTimeInfo';
 export { default as TourTypeBadge } from './TourTypeBadge';
+export { default as TouristContentsTypeFilter } from './TouristContentsTypeFilter';

--- a/src/config/QueryProvider.tsx
+++ b/src/config/QueryProvider.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@ export { default as truncate } from './truncate';
 export { default as getSuspenseLocation } from './getSuspenseLocation';
 export { default as useCurrentLocation } from './useCurrentLocation';
 export { default as getCurrentLocation } from './getCurrentLocation';
+export { default as isValidTourType } from './isValidTourType';

--- a/src/lib/isValidTourType.ts
+++ b/src/lib/isValidTourType.ts
@@ -1,0 +1,8 @@
+import { TOUR_TYPE } from '@/pages/const/MARKER';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+
+const isValidTourType = (value: string): value is AroundContentTypeId => {
+  return value in TOUR_TYPE;
+};
+
+export default isValidTourType;

--- a/src/lib/isValidTourType.ts
+++ b/src/lib/isValidTourType.ts
@@ -1,5 +1,5 @@
 import { TOUR_TYPE } from '@/pages/const/MARKER';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import type { AroundContentTypeId } from '@/pages/types';
 
 const isValidTourType = (value: string): value is AroundContentTypeId => {
   return value in TOUR_TYPE;

--- a/src/pages/map/aroundSearch/components/AroundTouristNavigate.tsx
+++ b/src/pages/map/aroundSearch/components/AroundTouristNavigate.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { FreeMode } from 'swiper/modules';
-import type { AroundContentTypeId, MarkerType } from '../types';
+import type { MarkerType } from '../types';
+import type { AroundContentTypeId } from '@/pages/types';
 
 interface AroundTouristNavigateProps {
   contentTypeIdGroup: MarkerType[];

--- a/src/pages/map/aroundSearch/lib/getAroundNavigate.ts
+++ b/src/pages/map/aroundSearch/lib/getAroundNavigate.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { markerImageMap, markerList } from '@/pages/const/MARKER';
-import type { GeoTripLocation } from '@/pages/types';
+import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
 import useAroundTouristQuery from '../service/getAroundTouristMapData';
-import type { AroundContentTypeId, MarkerType } from '../types';
+import type { MarkerType } from '../types';
 
 const useGetAroundNavigate = (destination: GeoTripLocation) => {
   const [contentTypeIdGroup, setContentTypeIdGroup] = useState<MarkerType[]>([

--- a/src/pages/map/aroundSearch/lib/getDestinationInfo.ts
+++ b/src/pages/map/aroundSearch/lib/getDestinationInfo.ts
@@ -1,5 +1,5 @@
-import { useLocation, useSearchParams } from 'react-router-dom';
-import type { AroundContentTypeId } from '../types';
+import type { AroundContentTypeId } from '@/pages/types';
+import { useSearchParams } from 'react-router-dom';
 
 const useGetDestinationInfo = () => {
   const [searchParams] = useSearchParams();

--- a/src/pages/map/aroundSearch/service/getAroundTouristMapData.ts
+++ b/src/pages/map/aroundSearch/service/getAroundTouristMapData.ts
@@ -1,8 +1,11 @@
 import api from '@/config/instance';
-import { type GeoTripLocation, type TourItem } from '@/pages/types';
+import {
+  type AroundContentTypeId,
+  type GeoTripLocation,
+  type TourItem,
+} from '@/pages/types';
 import { useQueries } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import type { AroundContentTypeId } from '../types';
 
 export type LocationBasedItemRequest = {
   location: GeoTripLocation;

--- a/src/pages/map/aroundSearch/service/getSelectedPinDetail.ts
+++ b/src/pages/map/aroundSearch/service/getSelectedPinDetail.ts
@@ -1,5 +1,4 @@
-import type { TourItem } from '@/pages/types';
-import type { AroundContentTypeId } from '../types';
+import type { AroundContentTypeId, TourItem } from '@/pages/types';
 import api from '@/config/instance';
 import { useQuery } from '@tanstack/react-query';
 

--- a/src/pages/map/aroundSearch/types.d.ts
+++ b/src/pages/map/aroundSearch/types.d.ts
@@ -1,15 +1,5 @@
 import type { TourSummary } from '@/pages/tour/geotrip/types';
-
-export type AroundContentTypeId =
-  | '' // 없음
-  | '12' // 관광지
-  | '14' // 문화시설
-  | '15' // 축제공연행사
-  | '25' // 여행코스
-  | '28' // 레포츠
-  | '32' // 숙박
-  | '38' // 쇼핑
-  | '39'; // 음식점
+import type { AroundContentTypeId } from '@pages/types';
 
 export type MarkerType = {
   contentTypeId: AroundContentTypeId;

--- a/src/pages/tour/Tour.tsx
+++ b/src/pages/tour/Tour.tsx
@@ -1,16 +1,9 @@
-import Header from '@/components/Header';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 export default function Tour() {
-  const location = useLocation();
-  const isGeoTrip = location.pathname === '/tour/geo-trip';
-
   return (
     <section className="flex flex-col h-full w-full">
       <div className="h-full w-full relative">
-        <Header className="w-full absolute flex items-center justify-between top-4 px-5 z-(--z-layer5)">
-          {!isGeoTrip && <h1>리스트</h1>}
-        </Header>
         <Outlet />
       </div>
     </section>

--- a/src/pages/tour/components/withGeoTripParams.tsx
+++ b/src/pages/tour/components/withGeoTripParams.tsx
@@ -7,7 +7,7 @@ import { isValidTourType } from '@/lib';
 interface InjectedProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: AroundContentTypeId;
+  tourContentTypeId: AroundContentTypeId;
 }
 
 export default function withGeoTripParams<P extends InjectedProps>(

--- a/src/pages/tour/components/withGeoTripParams.tsx
+++ b/src/pages/tour/components/withGeoTripParams.tsx
@@ -1,11 +1,12 @@
 import { useSearchParams } from 'react-router-dom';
 import type { GeoTripLocation } from '@/pages/types';
 import getSuspenseLocation from '@/lib/getSuspenseLocation';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 
 interface InjectedProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: number;
+  tourType: AroundContentTypeId;
 }
 
 export default function withGeoTripParams<P extends InjectedProps>(

--- a/src/pages/tour/components/withGeoTripParams.tsx
+++ b/src/pages/tour/components/withGeoTripParams.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from 'react-router-dom';
 import type { GeoTripLocation } from '@/pages/types';
 import getSuspenseLocation from '@/lib/getSuspenseLocation';
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import { isValidTourType } from '@/lib';
 
 interface InjectedProps {
   location: GeoTripLocation;
@@ -23,13 +24,16 @@ export default function withGeoTripParams<P extends InjectedProps>(
         <div>필요한 정보가 부족합니다. 거리와 관광지 타입을 확인해주세요.</div>
       );
     }
+    if (!isValidTourType(tourType)) {
+      return <div>잘못된 관광 타입입니다.</div>;
+    }
 
     return (
       <WrappedComponent
         {...(props as P)}
         location={geoLocation}
         distance={distance}
-        tourType={Number(tourType)}
+        tourType={tourType}
       />
     );
   };

--- a/src/pages/tour/components/withGeoTripParams.tsx
+++ b/src/pages/tour/components/withGeoTripParams.tsx
@@ -1,7 +1,6 @@
 import { useSearchParams } from 'react-router-dom';
-import type { GeoTripLocation } from '@/pages/types';
+import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
 import getSuspenseLocation from '@/lib/getSuspenseLocation';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 import { isValidTourType } from '@/lib';
 
 interface InjectedProps {
@@ -16,15 +15,15 @@ export default function withGeoTripParams<P extends InjectedProps>(
   return function GeoTripWrapper(props: Omit<P, keyof InjectedProps>) {
     const [searchParams] = useSearchParams();
     const distance = searchParams.get('distance');
-    const tourType = searchParams.get('tour-type');
+    const tourContentTypeId = searchParams.get('tour-type');
     const geoLocation = getSuspenseLocation();
 
-    if (!distance || !tourType) {
+    if (!distance || !tourContentTypeId) {
       return (
         <div>필요한 정보가 부족합니다. 거리와 관광지 타입을 확인해주세요.</div>
       );
     }
-    if (!isValidTourType(tourType)) {
+    if (!isValidTourType(tourContentTypeId)) {
       return <div>잘못된 관광 타입입니다.</div>;
     }
 
@@ -33,7 +32,7 @@ export default function withGeoTripParams<P extends InjectedProps>(
         {...(props as P)}
         location={geoLocation}
         distance={distance}
-        tourType={tourType}
+        tourContentTypeId={tourContentTypeId}
       />
     );
   };

--- a/src/pages/tour/geotrip/GeoTrip.tsx
+++ b/src/pages/tour/geotrip/GeoTrip.tsx
@@ -1,10 +1,12 @@
 import { LoadingSpinner } from '@/components';
+import Header from '@/components/Header';
 import { TourResultSwiper } from '@/pages/tour/geotrip/components';
 import { Suspense } from 'react';
 
 export default function GeoTrip() {
   return (
     <div className="absolute h-full w-full flex items-center justify-center">
+      <Header className="w-full absolute flex items-center justify-between top-4 px-5 z-(--z-layer5)" />
       <Suspense fallback={<LoadingSpinner />}>
         <TourResultSwiper />
       </Suspense>

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -10,10 +10,11 @@ import type { TourSummary } from '../types';
 import { SideButtonGroup } from './SideButtonGroup';
 import type { Swiper as SwiperType } from 'swiper/types';
 import { withGeoTripParams } from '@/pages/tour/components';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 interface TourResultSwiperProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: number;
+  tourType: AroundContentTypeId;
 }
 function TourResultSwiper({
   location,

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -2,7 +2,7 @@ import { Suspense, useMemo, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination, Navigation, Mousewheel } from 'swiper/modules';
 import TourSlide from './TourSlide';
-import type { GeoTripLocation } from '@/pages/types';
+import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
 import { useGeoLocationBasedTourQuery } from '../../service';
 import { BottomSheet, LoadingSpinner, TourCard } from '@/components';
 import { TourOverView } from './';
@@ -10,7 +10,6 @@ import type { TourSummary } from '../types';
 import { SideButtonGroup } from './SideButtonGroup';
 import type { Swiper as SwiperType } from 'swiper/types';
 import { withGeoTripParams } from '@/pages/tour/components';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 interface TourResultSwiperProps {
   location: GeoTripLocation;
   distance: string;

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -14,17 +14,17 @@ import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 interface TourResultSwiperProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: AroundContentTypeId;
+  tourContentTypeId: AroundContentTypeId;
 }
 function TourResultSwiper({
   location,
   distance,
-  tourType,
+  tourContentTypeId,
 }: TourResultSwiperProps) {
   const { data, fetchNextPage, hasNextPage } = useGeoLocationBasedTourQuery({
     location,
     radius: distance,
-    contentTypeId: tourType,
+    contentTypeId: tourContentTypeId,
   });
   const [showDetail, setShowDetail] = useState(false);
   const slides = useMemo(() => data.pages.flatMap(page => page.items), [data]);

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -7,9 +7,9 @@ import type {
   TourItemWithDetail,
   GeoTripLocation,
   ResponseBody,
+  AroundContentTypeId,
 } from '@/pages/types';
 import { NUM_OF_ROWS } from '@/pages/const/TOUR';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 
 type LocationBasedItemRequest = {
   location: GeoTripLocation | null;

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -39,7 +39,7 @@ const getLocationBasedData = async ({
         mapX: location.lng,
         mapY: location.lat,
         radius,
-        contentTypeId,
+        contentTypeId: Number(contentTypeId),
         numOfRows: NUM_OF_ROWS,
         arrange: 'S',
         pageNo,
@@ -54,11 +54,15 @@ const getLocationBasedData = async ({
   const settledResults = await Promise.allSettled(
     baseItems.map(async (item, index) => {
       try {
-        const params = { contentId: item.contentid, _type: 'json' };
-        const imageRes = await api.get<ApiResponse<TourDetailImage[]>>(
+        const params = { contentId: item.contentid };
+        const imageRes = await api.get<ApiResponse<TourDetailImage[] | ''>>(
           `/detailImage2`,
           { params }
         );
+        if (imageRes.data.response.body.items === '')
+          throw new Error(
+            `상세 이미지 데이터가 없습니다. contentid: ${item.contentid}`
+          );
 
         const firstImage: TourDetailImage = {
           imgname: baseItems[index].firstimage,
@@ -75,8 +79,7 @@ const getLocationBasedData = async ({
           images,
         };
       } catch (e) {
-        console.warn('상세정보 불러오기 실패:', item.contentid, e);
-        return null;
+        throw e;
       }
     })
   );

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -8,11 +8,12 @@ import type {
   GeoTripLocation,
 } from '@/pages/types';
 import { NUM_OF_ROWS } from '@/pages/const/TOUR';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 
 type LocationBasedItemRequest = {
   location: GeoTripLocation | null;
   pageNo: number;
-  contentTypeId?: number;
+  contentTypeId: AroundContentTypeId;
   radius?: string;
 };
 
@@ -26,7 +27,7 @@ type LocationBasedItemResponse = Promise<{
 const getLocationBasedData = async ({
   location,
   pageNo,
-  contentTypeId = 12,
+  contentTypeId = '12',
   radius = '5000',
 }: LocationBasedItemRequest): LocationBasedItemResponse => {
   if (!location) return Promise.reject('위치 정보가 없습니다.');

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -1,4 +1,4 @@
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { queryOptions, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import api from '@/config/instance';
 import type {
   ApiResponse,
@@ -126,8 +126,10 @@ const getLocationBasedData = async ({
 const useGeoLocationBasedTourQuery = (
   request: Omit<LocationBasedItemRequest, 'pageNo'>
 ) => {
+  queryOptions;
   const query = useSuspenseInfiniteQuery({
     queryKey: ['locationBasedData', request],
+
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>
       getLocationBasedData({

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -6,6 +6,7 @@ import type {
   TourDetailImage,
   TourItemWithDetail,
   GeoTripLocation,
+  ResponseBody,
 } from '@/pages/types';
 import { NUM_OF_ROWS } from '@/pages/const/TOUR';
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
@@ -24,14 +25,25 @@ type LocationBasedItemResponse = Promise<{
   totalCount: number;
 }>;
 
-const getLocationBasedData = async ({
-  location,
-  pageNo,
-  contentTypeId = '12',
-  radius = '5000',
-}: LocationBasedItemRequest): LocationBasedItemResponse => {
-  if (!location) return Promise.reject('위치 정보가 없습니다.');
+const fetchDetailImages = async (contentId: number) => {
+  const params = { contentId };
+  const imageRes = await api.get<ApiResponse<TourDetailImage[]>>(
+    `/detailImage2`,
+    { params }
+  );
+  if (imageRes.data.response.body.items === '') {
+    throw new Error(`no images`);
+  }
 
+  return imageRes.data.response.body.items.item;
+};
+
+const fetchLocationBasedItems = async (
+  location: GeoTripLocation,
+  pageNo: number,
+  contentTypeId: AroundContentTypeId,
+  radius: string
+) => {
   const response = await api.get<ApiResponse<TourItem[]>>(
     `/locationBasedList2`,
     {
@@ -46,53 +58,68 @@ const getLocationBasedData = async ({
       },
     }
   );
-  if (!response.data.response.body.items) {
-    return Promise.reject('위치 기반 데이터가 없습니다.');
+
+  if (response.data.response.body.items === '') {
+    throw new Error('아이템 데이터가 없습니다.');
   }
 
-  const baseItems = response.data.response.body.items.item;
+  return response.data.response.body as Omit<
+    ResponseBody<TourItem[]>,
+    'items'
+  > & { items: { item: TourItem[] } };
+};
+
+const attachDetailImages = async (
+  baseItems: TourItem[]
+): Promise<TourItemWithDetail[]> => {
   const settledResults = await Promise.allSettled(
     baseItems.map(async (item, index) => {
+      const firstImage: TourDetailImage = {
+        imgname: item.firstimage,
+        originimgurl: item.firstimage,
+        serialnum: item.firstimage + String(index),
+      };
       try {
-        const params = { contentId: item.contentid };
-        const imageRes = await api.get<ApiResponse<TourDetailImage[] | ''>>(
-          `/detailImage2`,
-          { params }
-        );
-        if (imageRes.data.response.body.items === '')
-          throw new Error(
-            `상세 이미지 데이터가 없습니다. contentid: ${item.contentid}`
-          );
+        const imageArray = await fetchDetailImages(item.contentid);
 
-        const firstImage: TourDetailImage = {
-          imgname: baseItems[index].firstimage,
-          originimgurl: baseItems[index].firstimage,
-          serialnum: String(index),
-        };
-
-        const images = imageRes.data.response.body.items.item
-          ? [...imageRes.data.response.body.items.item]
-          : [firstImage];
-
-        return {
-          ...item,
-          images,
-        };
-      } catch (e) {
-        throw e;
+        return { ...item, images: imageArray };
+      } catch (error) {
+        if (error instanceof Error && error.message === 'no images') {
+          return { ...item, images: [firstImage] };
+        }
       }
     })
   );
 
-  const itemsWithDetail = settledResults
+  return settledResults
     .filter(r => r.status === 'fulfilled' && r.value !== null)
     .map(r => (r as PromiseFulfilledResult<TourItemWithDetail>).value);
+};
+
+const getLocationBasedData = async ({
+  location,
+  pageNo,
+  contentTypeId = '12',
+  radius = '5000',
+}: LocationBasedItemRequest): LocationBasedItemResponse => {
+  if (!location) throw new Error('위치 정보가 없습니다.');
+
+  const body = await fetchLocationBasedItems(
+    location,
+    pageNo,
+    contentTypeId,
+    radius
+  );
+
+  const baseItems = body.items.item;
+
+  const itemsWithDetail = await attachDetailImages(baseItems);
 
   return {
     items: itemsWithDetail,
-    pageNo: response.data.response.body.pageNo,
-    numOfRows: response.data.response.body.numOfRows,
-    totalCount: response.data.response.body.totalCount,
+    pageNo: body.pageNo,
+    numOfRows: body.numOfRows,
+    totalCount: body.totalCount,
   };
 };
 

--- a/src/pages/tour/tourList/TourList.tsx
+++ b/src/pages/tour/tourList/TourList.tsx
@@ -1,4 +1,4 @@
-import { SkeletonCard } from './components';
+import { SkeletonCard, TouristFilterQueryUpdater } from './components';
 import TourListContainer from '@/pages/tour/tourList/components/TourListContainer';
 import { Suspense } from 'react';
 import Header from '@/components/Header';
@@ -10,6 +10,7 @@ export default function TourList() {
       <Header className="w-full flex items-center justify-between px-5 mt-1.5">
         <h1>리스트</h1>
       </Header>
+      <TouristFilterQueryUpdater />
       <Suspense
         fallback={fallbackList.map(v => (
           <div key={v} className="my-1">

--- a/src/pages/tour/tourList/TourList.tsx
+++ b/src/pages/tour/tourList/TourList.tsx
@@ -1,13 +1,17 @@
+import { TouristContentsTypeFilter } from '@/components';
 import { SkeletonCard } from './components';
 import TourListContainer from '@/pages/tour/tourList/components/TourListContainer';
 import { Suspense } from 'react';
+import Header from '@/components/Header';
 const fallbackList = [1, 2, 3, 4, 5];
 
 export default function TourList() {
   return (
     <div className="absolute h-full w-full overflow-auto ">
-      <h1 className="absolute right-1/2 translate-x-1/2 top-5">리스트</h1>
-      <div className="mt-15">선택리스트</div>
+      <Header className="w-full flex items-center justify-between px-5 mt-1.5">
+        <h1>리스트</h1>
+      </Header>
+      <TouristContentsTypeFilter />
       <Suspense
         fallback={fallbackList.map(v => (
           <div key={v} className="my-1">

--- a/src/pages/tour/tourList/TourList.tsx
+++ b/src/pages/tour/tourList/TourList.tsx
@@ -7,7 +7,7 @@ const fallbackList = [1, 2, 3, 4, 5];
 export default function TourList() {
   return (
     <div className="absolute h-full w-full overflow-auto ">
-      <Header className="w-full flex items-center justify-between px-5 mt-1.5">
+      <Header className="w-full flex items-center justify-between px-5 mt-1.5 mb-6">
         <h1>리스트</h1>
       </Header>
       <TouristFilterQueryUpdater />

--- a/src/pages/tour/tourList/TourList.tsx
+++ b/src/pages/tour/tourList/TourList.tsx
@@ -1,4 +1,3 @@
-import { TouristContentsTypeFilter } from '@/components';
 import { SkeletonCard } from './components';
 import TourListContainer from '@/pages/tour/tourList/components/TourListContainer';
 import { Suspense } from 'react';
@@ -11,7 +10,6 @@ export default function TourList() {
       <Header className="w-full flex items-center justify-between px-5 mt-1.5">
         <h1>리스트</h1>
       </Header>
-      <TouristContentsTypeFilter />
       <Suspense
         fallback={fallbackList.map(v => (
           <div key={v} className="my-1">

--- a/src/pages/tour/tourList/components/InfiniteScroll.tsx
+++ b/src/pages/tour/tourList/components/InfiniteScroll.tsx
@@ -24,7 +24,7 @@ export default function InfiniteScroll({
           onIntersect();
         }
       },
-      { threshold: 1 }
+      { threshold: 0.1 }
     );
 
     const el = observerRef.current;

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -9,35 +9,35 @@ import { queryClient } from '@/config/QueryProvider';
 interface TourListContainerProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: AroundContentTypeId;
+  tourContentTypeId: AroundContentTypeId;
 }
 
 function TourListContainer({
   location,
   distance,
-  tourType,
+  tourContentTypeId,
 }: TourListContainerProps) {
-  const [localTourType] = useSyncedState(tourType);
-  const deferredTourType = useDeferredValue(localTourType);
+  const [localTourContentTypeId] = useSyncedState(tourContentTypeId);
+  const deferredTourContentTypeId = useDeferredValue(localTourContentTypeId);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGeoLocationBasedTourQuery({
       location,
       radius: distance,
-      contentTypeId: deferredTourType,
+      contentTypeId: deferredTourContentTypeId,
     });
   const cachedData = queryClient.getQueryData([
     'locationBasedData',
     {
       location,
       radius: distance,
-      contentTypeId: localTourType,
+      contentTypeId: localTourContentTypeId,
     },
   ]);
 
   const tourItems = data.pages.flatMap(page => page.items);
 
   const hasCache = Boolean(cachedData);
-  const isSwitching = localTourType !== deferredTourType;
+  const isSwitching = localTourContentTypeId !== deferredTourContentTypeId;
   const showFallback = isSwitching && !hasCache;
 
   return (

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -4,6 +4,7 @@ import type { GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
 
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import { useDeferredValue, useEffect, useState } from 'react';
 interface TourListContainerProps {
   location: GeoTripLocation;
   distance: string;
@@ -14,25 +15,34 @@ function TourListContainer({
   distance,
   tourType,
 }: TourListContainerProps) {
+  const [localTourType, setLocalTourType] = useState(tourType);
+  const deferredTourType = useDeferredValue(localTourType);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGeoLocationBasedTourQuery({
       location,
       radius: distance,
-      contentTypeId: tourType,
+      contentTypeId: deferredTourType,
     });
-
   const tourItems = data.pages.flatMap(page => page.items);
+
+  useEffect(() => {
+    setLocalTourType(tourType);
+  }, [tourType]);
 
   return (
     <>
-      {tourItems.map(tourInfo => (
-        <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
-      ))}
+      <section className="relative">
+        {tourItems.map(tourInfo => (
+          <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
+        ))}
+        {localTourType !== deferredTourType && (
+          <div className="absolute inset-0 bg-gray-300/40 z-10" />
+        )}
+      </section>
       <InfiniteScroll
         hasNextPage={hasNextPage}
         isFetching={isFetchingNextPage}
         onIntersect={() => {
-          console.log('Intersection detected');
           fetchNextPage();
         }}
         LoadingComponent={<SkeletonCard />}

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -2,26 +2,36 @@ import { withGeoTripParams } from '@/pages/tour/components';
 import { useGeoLocationBasedTourQuery } from '../../service';
 import type { GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
+import { TouristContentsTypeFilter } from '@/components';
+import { useState } from 'react';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 interface TourListContainerProps {
   location: GeoTripLocation;
   distance: string;
-  tourType: number;
+  tourType: AroundContentTypeId;
 }
 function TourListContainer({
   location,
   distance,
   tourType,
 }: TourListContainerProps) {
+  const [contentTypeId, setContentTypeId] =
+    useState<AroundContentTypeId>(tourType);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGeoLocationBasedTourQuery({
       location,
       radius: distance,
-      contentTypeId: tourType,
+      contentTypeId: contentTypeId,
     });
+
   const tourItems = data.pages.flatMap(page => page.items);
 
   return (
     <>
+      <TouristContentsTypeFilter
+        contentTypeId={contentTypeId}
+        setContentTypeId={setContentTypeId}
+      />
       {tourItems.map(tourInfo => (
         <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
       ))}

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -2,8 +2,7 @@ import { withGeoTripParams } from '@/pages/tour/components';
 import { useGeoLocationBasedTourQuery } from '../../service';
 import type { GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
-import { TouristContentsTypeFilter } from '@/components';
-import { useState } from 'react';
+
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 interface TourListContainerProps {
   location: GeoTripLocation;
@@ -15,30 +14,27 @@ function TourListContainer({
   distance,
   tourType,
 }: TourListContainerProps) {
-  const [contentTypeId, setContentTypeId] =
-    useState<AroundContentTypeId>(tourType);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGeoLocationBasedTourQuery({
       location,
       radius: distance,
-      contentTypeId: contentTypeId,
+      contentTypeId: tourType,
     });
 
   const tourItems = data.pages.flatMap(page => page.items);
 
   return (
     <>
-      <TouristContentsTypeFilter
-        contentTypeId={contentTypeId}
-        setContentTypeId={setContentTypeId}
-      />
       {tourItems.map(tourInfo => (
         <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
       ))}
       <InfiniteScroll
         hasNextPage={hasNextPage}
         isFetching={isFetchingNextPage}
-        onIntersect={fetchNextPage}
+        onIntersect={() => {
+          console.log('Intersection detected');
+          fetchNextPage();
+        }}
         LoadingComponent={<SkeletonCard />}
       />
     </>

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -4,7 +4,8 @@ import type { GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
 
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
-import { useDeferredValue, useEffect, useState } from 'react';
+import { useDeferredValue, useEffect } from 'react';
+import { useSyncedState } from '../lib';
 interface TourListContainerProps {
   location: GeoTripLocation;
   distance: string;
@@ -15,7 +16,7 @@ function TourListContainer({
   distance,
   tourType,
 }: TourListContainerProps) {
-  const [localTourType, setLocalTourType] = useState(tourType);
+  const [localTourType] = useSyncedState(tourType);
   const deferredTourType = useDeferredValue(localTourType);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGeoLocationBasedTourQuery({
@@ -24,10 +25,7 @@ function TourListContainer({
       contentTypeId: deferredTourType,
     });
   const tourItems = data.pages.flatMap(page => page.items);
-
-  useEffect(() => {
-    setLocalTourType(tourType);
-  }, [tourType]);
+  const isPending = localTourType !== deferredTourType;
 
   return (
     <>
@@ -35,8 +33,8 @@ function TourListContainer({
         {tourItems.map(tourInfo => (
           <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
         ))}
-        {localTourType !== deferredTourType && (
-          <div className="absolute inset-0 bg-gray-300/40 z-10" />
+        {isPending && (
+          <div className="absolute inset-0 bg-primary-gray/40 z-10" />
         )}
       </section>
       <InfiniteScroll

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -1,8 +1,7 @@
 import { withGeoTripParams } from '@/pages/tour/components';
 import { useGeoLocationBasedTourQuery } from '../../service';
-import type { GeoTripLocation } from '@/pages/types';
+import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
 import { useDeferredValue } from 'react';
 import { useSyncedState } from '../lib';
 import { queryClient } from '@/config/QueryProvider';

--- a/src/pages/tour/tourList/components/TourListContainer.tsx
+++ b/src/pages/tour/tourList/components/TourListContainer.tsx
@@ -1,24 +1,22 @@
 import { withGeoTripParams } from '@/pages/tour/components';
 import { useGeoLocationBasedTourQuery } from '../../service';
-import type { GeoTripLocation, TourItemWithDetail } from '@/pages/types';
+import type { GeoTripLocation } from '@/pages/types';
 import { InfiniteScroll, SkeletonCard, TourInfoCard } from '.';
-
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
-import { useDeferredValue, useEffect } from 'react';
+import { useDeferredValue } from 'react';
 import { useSyncedState } from '../lib';
-import { QueryClient } from '@tanstack/react-query';
+import { queryClient } from '@/config/QueryProvider';
 interface TourListContainerProps {
   location: GeoTripLocation;
   distance: string;
   tourType: AroundContentTypeId;
 }
+
 function TourListContainer({
   location,
   distance,
   tourType,
 }: TourListContainerProps) {
-  const queryClient = new QueryClient();
-
   const [localTourType] = useSyncedState(tourType);
   const deferredTourType = useDeferredValue(localTourType);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -27,17 +25,20 @@ function TourListContainer({
       radius: distance,
       contentTypeId: deferredTourType,
     });
-  const cacheData = queryClient.getQueryState<TourItemWithDetail[]>([
+  const cachedData = queryClient.getQueryData([
     'locationBasedData',
     {
       location,
       radius: distance,
-      contentTypeId: deferredTourType,
+      contentTypeId: localTourType,
     },
   ]);
 
   const tourItems = data.pages.flatMap(page => page.items);
-  const isPending = localTourType !== deferredTourType || cacheData?.data;
+
+  const hasCache = Boolean(cachedData);
+  const isSwitching = localTourType !== deferredTourType;
+  const showFallback = isSwitching && !hasCache;
 
   return (
     <>
@@ -45,7 +46,7 @@ function TourListContainer({
         {tourItems.map(tourInfo => (
           <TourInfoCard tourInfo={tourInfo} key={tourInfo.contentid} />
         ))}
-        {isPending && (
+        {showFallback && (
           <div className="absolute inset-0 bg-primary-gray/40 z-10" />
         )}
       </section>

--- a/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
+++ b/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
@@ -1,8 +1,11 @@
 import { TouristContentsTypeFilter } from '@/components';
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type TransitionStartFunction } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+interface TouristFilterQueryUpdaterProps {
+  startTransition: TransitionStartFunction;
+}
 export default function TouristFilterQueryUpdater() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [contentTypeId, setContentTypeId] = useState<AroundContentTypeId>(

--- a/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
+++ b/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
@@ -1,0 +1,25 @@
+import { TouristContentsTypeFilter } from '@/components';
+import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export default function TouristFilterQueryUpdater() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [contentTypeId, setContentTypeId] = useState<AroundContentTypeId>(
+    searchParams.get('tour-type') as AroundContentTypeId
+  );
+
+  useEffect(() => {
+    searchParams.set('tour-type', contentTypeId);
+    setSearchParams(searchParams, { replace: true });
+  }, [contentTypeId]);
+
+  return (
+    <>
+      <TouristContentsTypeFilter
+        contentTypeId={contentTypeId}
+        setContentTypeId={setContentTypeId}
+      />
+    </>
+  );
+}

--- a/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
+++ b/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
@@ -1,5 +1,5 @@
 import { TouristContentsTypeFilter } from '@/components';
-import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
+import type { AroundContentTypeId } from '@/pages/types';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 

--- a/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
+++ b/src/pages/tour/tourList/components/TouristFilterQueryUpdater.tsx
@@ -1,11 +1,8 @@
 import { TouristContentsTypeFilter } from '@/components';
 import type { AroundContentTypeId } from '@/pages/map/aroundSearch/types';
-import { useEffect, useState, type TransitionStartFunction } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-interface TouristFilterQueryUpdaterProps {
-  startTransition: TransitionStartFunction;
-}
 export default function TouristFilterQueryUpdater() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [contentTypeId, setContentTypeId] = useState<AroundContentTypeId>(

--- a/src/pages/tour/tourList/components/index.ts
+++ b/src/pages/tour/tourList/components/index.ts
@@ -2,3 +2,4 @@ export { default as TourInfoCard } from './TourInfoCard';
 export { default as TourListContainer } from './TourListContainer';
 export { default as SkeletonCard } from './SkeletonCard';
 export { default as InfiniteScroll } from './InfiniteScroll';
+export { default as TouristFilterQueryUpdater } from './TouristFilterQueryUpdater';

--- a/src/pages/tour/tourList/lib/index.ts
+++ b/src/pages/tour/tourList/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as useSyncedState } from './useSyncedState';

--- a/src/pages/tour/tourList/lib/useSyncedState.ts
+++ b/src/pages/tour/tourList/lib/useSyncedState.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const useSyncedState = <T>(
+  externalValue: T
+): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const [localValue, setLocalValue] = useState(externalValue);
+
+  useEffect(() => {
+    setLocalValue(externalValue);
+  }, [externalValue]);
+
+  return [localValue, setLocalValue];
+};
+
+export default useSyncedState;

--- a/src/pages/types.d.ts
+++ b/src/pages/types.d.ts
@@ -1,5 +1,3 @@
-import type { AroundContentTypeId } from './map/aroundSearch/types';
-
 export type ApiResponse<T> = {
   response: { header: ResponseHeader; body: ResponseBody<T> };
 };
@@ -66,3 +64,14 @@ export type TourDetailResponse = {
 export type TourItemWithDetail = TourItem & {
   images: TourDetailImage[];
 };
+
+export type AroundContentTypeId =
+  | '' // 없음
+  | '12' // 관광지
+  | '14' // 문화시설
+  | '15' // 축제공연행사
+  | '25' // 여행코스
+  | '28' // 레포츠
+  | '32' // 숙박
+  | '38' // 쇼핑
+  | '39'; // 음식점

--- a/src/pages/types.d.ts
+++ b/src/pages/types.d.ts
@@ -15,7 +15,7 @@ export type ResponseBody<T> = {
   numOfRows: number;
   pageNo: number;
   totalCount: number;
-  items: { item: T };
+  items: { item: T } | '';
 };
 
 export type GeoTripLocation = {


### PR DESCRIPTION
## 🔗 관련 이슈
#45
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
![image](https://github.com/user-attachments/assets/72a36d6d-1cc7-4db5-b8ae-8f22de6207b5)
기존 만들어두신 컴포넌트와는 ui, 기능, 의존성등이 맞지 않아 새롭
`state`와 `setState`를 전달받아 사용할 수 있는 컴포넌트 `TouristContentsTypeFilter`를 생성했습니다.

## 기능 구현 중 이슈🤔

https://github.com/user-attachments/assets/2dad24ad-faaa-44a6-a577-0f37efa22d0f

`fallback UI` 없이 데이터 요청 후 갑자기 화면 전환이 이루어지는 이슈 발생

**flow 정리**
  1. 투어 타입 중 관광지 클릭 시 `'12'` 로 state 업데이트
  2. `useEffect`를 통해 **state 업데이트 시** 쿼리 파라미터 설정
  3. 고차 컴포넌트를 통해 `TourListContainer` 컴포넌트는 현재 **위치, 거리, 투어 타입 등 요청에 필요한 정보를 주입**받음
  4. `tourType`을 `query Key`로 사용중이기 때문에 데이터 재요청 
  5. 하지만 `suspenseQuery`는 기본적으로 이미 캐싱된 데이터가 있을 시 또 `fallback`을 보여주지 않음 (기본 동작)

**해결 방법**
`useDeferredValue`를 활용
  1. 다른 투어 타입 클릭 → localTourType = 14
  2. 초기 useDeferredValue 값은 여전히 12 → deferredTourType !== localTourType → fallback UI 표시
  3. React 여유 생기면 useDeferredValue 값이 14로 업데이트
  4. deferredTourType가 변경되면서 query key 변경 → 재요청
  5. fetch 후, 컴포넌트 재렌더 → fallback 사라짐
  
해당 훅을 사용하는걸 권장 하더라구요
[레퍼런스1](https://github.com/TanStack/query/discussions/6327?utm_source=chatgpt.com)
[레퍼런스2](https://github.com/TanStack/query/discussions/7661)
  <!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 추가 개선할만한 사항
![image](https://github.com/user-attachments/assets/bb282569-a0ee-4078-b080-a3730fa92e44)
주변 조회 => 주변 기반 이미지 전부 조회 구조인데 밑에 보시면  동시 커넥션 수가 부족해서 밀려나는 몇개 요청이 보입니다.

이를 `useSuspenseInfinityQuery` + `useSuspenseQuries`로 개선하면 어떨까 싶습니다
여러 서스펜스 쿼리를 하면 병렬처리가 안되고 자동으로 처음 요청 후 다음 요청을 보내기에 현재 구조와도 적합하고
`Nested Suspense`라고 중첩 서스펜스 구조인데 차례차례 로딩되는 형식으로 바꾸면 ui/ux적으로 좋다고도 합니다


## 🔍 변경 사항

- [ ] 데이터 요청 함수 부분 쪼개기
- [ ] TouristContentsTypeFilter 생성


## 💬리뷰 요구사항 (선택사항)
구현 중 이슈와 flow 정리는 개인 소장? 용으로 써놓은거라 굳이 꼼꼼히 체크 안해주셔도 될 것 같습니다!