### PR TITLE
쿼리 옵션으로 수정

### DIFF
--- a/src/pages/map/aroundSearch/components/GeoAroundTouristMap.tsx
+++ b/src/pages/map/aroundSearch/components/GeoAroundTouristMap.tsx
@@ -8,10 +8,11 @@ import type {
   GeoTripLocation,
   TourItem,
 } from '@/pages/types';
-import useAroundTouristQuery from '../service/getAroundTouristMapData';
+import getAroundTouristQueryOptions from '../service/getAroundTouristMapData';
 import { withAroundMapParams } from '../../components';
 import { ResizingMap } from '../../destination/components';
 import MiddleContent from './MiddleContent';
+import { useQuery } from '@tanstack/react-query';
 
 interface GeoAroundTouristMapProps {
   location: GeoTripLocation;
@@ -25,10 +26,11 @@ function GeoAroundTouristMap({
 }: GeoAroundTouristMapProps) {
   const [selectedContentTypeId, setSelectedContentTypeId] =
     useState<AroundContentTypeId>(tourContentTypeId);
-  const aroundTouristObjects = useAroundTouristQuery(
-    location,
-    selectedContentTypeId
+  const {data:aroundTouristObjects} = useQuery(getAroundTouristQueryOptions(location,
+    selectedContentTypeId)
+   
   );
+  
   const middleTouristRef = useRef<TourItem | null>(null);
 
   const middleTouristObject = useMemo(() => {

--- a/src/pages/map/aroundSearch/service/getAroundTouristMapData.ts
+++ b/src/pages/map/aroundSearch/service/getAroundTouristMapData.ts
@@ -4,7 +4,6 @@ import type {
   GeoTripLocation,
   TourItem,
 } from '@/pages/types';
-import { useQuery } from '@tanstack/react-query';
 
 export type LocationBasedItemRequest = {
   location: GeoTripLocation;
@@ -41,16 +40,12 @@ const getAroundTouristMapData = async ({
   return response.data.response.body;
 };
 
-const useAroundTouristQuery = (
+const getAroundTouristQueryOptions = (
   destination: GeoTripLocation,
   contentTypeId: AroundContentTypeId
-) => {
-  const response = useQuery({
-    queryKey: ['aroundTouristMapData', destination, contentTypeId],
-    queryFn: () =>
-      getAroundTouristMapData({ location: destination, contentTypeId }),
-  });
-  return response.data?.items.item || [];
-};
+) => ({
+  queryKey: ['aroundTouristMapData', destination, contentTypeId],
+  queryFn: () => getAroundTouristMapData({ location: destination, contentTypeId }),
+});
 
-export default useAroundTouristQuery;
+export default getAroundTouristQueryOptions;

--- a/src/pages/map/aroundSearch/service/getSelectedPinDetail.ts
+++ b/src/pages/map/aroundSearch/service/getSelectedPinDetail.ts
@@ -29,15 +29,12 @@ const getSelectedPinDetail = async ({
   return response.data.response.body;
 };
 
-const useGetSelectedPinDetail = ({
+const getSelectedPinDetailQueryOptions = ({
   contentId,
   contentTypeId,
-}: GetSelectedPinDetailRequest) => {
-  const selectedPin = useQuery({
-    queryKey: ['selectedPinDetail', contentId, contentTypeId],
-    queryFn: () => getSelectedPinDetail({ contentId, contentTypeId }),
-  });
-  return selectedPin.data?.items.item[0] || null;
-};
+}: GetSelectedPinDetailRequest) => ({
+  queryKey: ['selectedPinDetail', contentId, contentTypeId],
+  queryFn: () => getSelectedPinDetail({ contentId, contentTypeId }),
+});
 
-export default useGetSelectedPinDetail;
+export default getSelectedPinDetailQueryOptions;

--- a/src/pages/map/aroundSearch/service/index.ts
+++ b/src/pages/map/aroundSearch/service/index.ts
@@ -1,0 +1,2 @@
+export {default as getAroundTouristQueryOptions} from './getAroundTouristMapData';
+export {default as getSelectedPinDetailQueryOptions} from './getSelectedPinDetail';

--- a/src/pages/map/destination/service/index.ts
+++ b/src/pages/map/destination/service/index.ts
@@ -1,1 +1,2 @@
 export { default as selectedTransportation } from './getTransportationSelected';
+export { default as getCarDestinationQueryOptions} from'./getCarData';

--- a/src/pages/tour/geotrip/components/TourOverView.tsx
+++ b/src/pages/tour/geotrip/components/TourOverView.tsx
@@ -1,10 +1,11 @@
-import { useGetTourDetailSuspenseQuery } from '@/pages/tour/service';
+import { getTourDetailQueryOptions } from '@/pages/tour/service';
+import { useSuspenseQuery } from '@tanstack/react-query';
 interface TourOverViewProps {
   contentId: string | null;
 }
 
 export default function TourOverView({ contentId }: TourOverViewProps) {
-  const { data } = useGetTourDetailSuspenseQuery({ contentId });
+  const { data } = useSuspenseQuery(getTourDetailQueryOptions({contentId}))
 
   return <div className="overflow-auto px-4">{data.overview}</div>;
 }

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -3,7 +3,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination, Navigation, Mousewheel } from 'swiper/modules';
 import TourSlide from './TourSlide';
 import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
-import { useGeoLocationBasedTourQuery } from '../../service';
+import { getGeoLocationBasedTourQueryOptions } from '../../service';
 import { BottomSheet, LoadingSpinner, TourCard } from '@/components';
 import { TourOverView } from './';
 import type { TourSummary } from '../types';
@@ -11,6 +11,7 @@ import { SideButtonGroup } from './SideButtonGroup';
 import type { Swiper as SwiperType } from 'swiper/types';
 import { withGeoTripParams } from '@/pages/tour/components';
 import { useStartTrip } from '../lib';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 interface TourResultSwiperProps {
   location: GeoTripLocation;
   distance: string;
@@ -21,11 +22,11 @@ function TourResultSwiper({
   distance,
   tourContentTypeId,
 }: TourResultSwiperProps) {
-  const { data, fetchNextPage, hasNextPage } = useGeoLocationBasedTourQuery({
+  const { data, fetchNextPage, hasNextPage } = useSuspenseInfiniteQuery(getGeoLocationBasedTourQueryOptions({
     location,
     radius: distance,
     contentTypeId: tourContentTypeId,
-  });
+  }));
   const [showDetail, setShowDetail] = useState(false);
   const slides = useMemo(() => data.pages.flatMap(page => page.items), [data]);
   const [currentTourInfo, setCurrentTourInfo] = useState<TourSummary>({

--- a/src/pages/tour/service/getLocationBasedData.ts
+++ b/src/pages/tour/service/getLocationBasedData.ts
@@ -1,4 +1,4 @@
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { queryOptions, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import api from '@/config/instance';
 import type {
   ApiResponse,
@@ -18,12 +18,12 @@ type LocationBasedItemRequest = {
   radius?: string;
 };
 
-type LocationBasedItemResponse = Promise<{
+type LocationBasedItemResponse = {
   items: TourItemWithDetail[];
   pageNo: number;
   numOfRows: number;
   totalCount: number;
-}>;
+};
 
 const fetchDetailImages = async (contentId: string) => {
   const params = { contentId };
@@ -101,7 +101,7 @@ const getLocationBasedData = async ({
   pageNo,
   contentTypeId = '12',
   radius = '5000',
-}: LocationBasedItemRequest): LocationBasedItemResponse => {
+}: LocationBasedItemRequest): Promise<LocationBasedItemResponse> => {
   if (!location) throw new Error('위치 정보가 없습니다.');
 
   const body = await fetchLocationBasedItems(
@@ -123,28 +123,24 @@ const getLocationBasedData = async ({
   };
 };
 
-const useGeoLocationBasedTourQuery = (
+const getGeoLocationBasedTourQueryOptions = (
   request: Omit<LocationBasedItemRequest, 'pageNo'>,
-) => {
-  const query = useSuspenseInfiniteQuery({
-    queryKey: ['locationBasedData', request],
+) => ({
+  queryKey: ['locationBasedData', request],
+  initialPageParam: 1,
+  queryFn: ({ pageParam }: { pageParam: number }) =>
+    getLocationBasedData({
+      location: request.location,
+      pageNo: pageParam,
+      contentTypeId: request.contentTypeId,
+      radius: request.radius,
+    }),
+  getNextPageParam: (lastPage: LocationBasedItemResponse) => {
+    
+    const currentPage = lastPage.pageNo;
+    const totalPage = Math.ceil(lastPage.totalCount / lastPage.numOfRows);
+    return currentPage < totalPage ? currentPage + 1 : undefined;
+  },
+});
 
-    initialPageParam: 1,
-    queryFn: ({ pageParam }) =>
-      getLocationBasedData({
-        location: request.location,
-        pageNo: pageParam,
-        contentTypeId: request.contentTypeId,
-        radius: request.radius,
-      }),
-    getNextPageParam: lastPage => {
-      const currentPage = lastPage.pageNo;
-      const totalPage = Math.ceil(lastPage.totalCount / lastPage.numOfRows);
-      return currentPage < totalPage ? currentPage + 1 : undefined;
-    },
-  });
-
-  return query;
-};
-
-export default useGeoLocationBasedTourQuery;
+export default getGeoLocationBasedTourQueryOptions;

--- a/src/pages/tour/service/getTourDetail.ts
+++ b/src/pages/tour/service/getTourDetail.ts
@@ -27,6 +27,10 @@ const getTourDetail = async ({
   return items.item[0];
 };
 
+ const getTourDetailQueryOptions = ({ contentId }: getTourDetailRequest) => ({
+  queryKey: ['tourDetail', contentId],
+  queryFn: () => getTourDetail({ contentId }),
+});
 const useGetTourDetailSuspenseQuery = ({ contentId }: getTourDetailRequest) => {
   return useSuspenseQuery({
     queryKey: ['tourDetail', contentId],
@@ -34,4 +38,4 @@ const useGetTourDetailSuspenseQuery = ({ contentId }: getTourDetailRequest) => {
   });
 };
 
-export default useGetTourDetailSuspenseQuery;
+export default getTourDetailQueryOptions;

--- a/src/pages/tour/service/index.ts
+++ b/src/pages/tour/service/index.ts
@@ -1,2 +1,2 @@
 export { default as getGeoLocationBasedTourQueryOptions } from './getLocationBasedData';
-export { default as useGetTourDetailSuspenseQuery } from './getTourDetail';
+export { default as getTourDetailQueryOptions } from './getTourDetail';

--- a/src/pages/tour/service/index.ts
+++ b/src/pages/tour/service/index.ts
@@ -1,2 +1,2 @@
-export { default as useGeoLocationBasedTourQuery } from './getLocationBasedData';
+export { default as getGeoLocationBasedTourQueryOptions } from './getLocationBasedData';
 export { default as useGetTourDetailSuspenseQuery } from './getTourDetail';


### PR DESCRIPTION
## 🔗 관련 이슈
#63 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
```tsx
 const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
    useSuspenseInfiniteQuery(getGeoLocationBasedTourQueryOptions({
      location,
      radius: distance,
      contentTypeId: deferredTourContentTypeId,
    }));
```
위와같이 `useQuery`등에 쿼리 옵션을 반환해주는 `getGeoLocationBasedTourQueryOptions` 함수를 사용해 옵션을 전달해줍니다.

```tsx
  const queryOptionsForCache = getGeoLocationBasedTourQueryOptions({
      location,
      radius: distance,
      contentTypeId: localTourContentTypeId,
    })

  const cachedData = queryClient.getQueryData(queryOptionsForCache.queryKey);
```
### 장점
위와같이 queryKey를 사용해야하는 부분에서 불필요한 하드코딩을 피할 수 있습니다
```tsx
//쿼리 키 하드코딩
const cachedData = queryClient.getQueryData([
    'locationBasedData',
    {
      location,
      radius: distance,
      contentTypeId: localTourContentTypeId,
    },
  ]);
//쿼리 옵션 사용
const queryOptionsForCache = getGeoLocationBasedTourQueryOptions({
      location,
      radius: distance,
      contentTypeId: localTourContentTypeId,
    })

 const cachedData = queryClient.getQueryData(queryOptionsForCache.queryKey);
```
2. 
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
`getAroundTouristMapData`파일입니다.
```ts
const getAroundTouristMapData = async ({
  location,
  contentTypeId,
}: LocationBasedItemRequest): LocationBasedItemResponse => {
  if (!location) return Promise.reject('위치 정보가 없습니다.');

  const response = await api.get(`/locationBasedList2`, {
    params: {
      mapX: location.lng,
      mapY: location.lat,
      arrange: 'E',
      radius: '3000',
      numOfRows: 30,
      contentTypeId,
      pageNo: 1,
    },
  });

  return response.data.response.body;
};

const getAroundTouristQueryOptions = (
  destination: GeoTripLocation,
  contentTypeId: AroundContentTypeId
) => ({
  queryKey: ['aroundTouristMapData', destination, contentTypeId],
  queryFn: () => getAroundTouristMapData({ location: destination, contentTypeId }),
});

export default getAroundTouristQueryOptions;
```
위 파일에서 원래 `query`부분에서 리턴값을 data.body.items로 반환하도록 지정이 되어있었는데 해당 파일에서
옵션만 선언하도록 바뀌면서 해당 쿼리를 사용하는 부분에서 타입 에러가 발생합니다.
제 생각에는 `api`요청 함수의 반환값을 수정해주면 될 것 같은데 @zzzRYT 님 의견은 어떠신지 PR올려봤습니다!