### PR TITLE
숏폼 네트워크 최적화

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "motion": "^12.16.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-error-boundary": "^6.0.0",
     "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^7.6.1",
     "swiper": "^11.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-error-boundary:
+        specifier: ^6.0.0
+        version: 6.0.0(react@19.1.0)
       react-kakao-maps-sdk:
         specifier: ^1.1.27
         version: 1.1.27(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2127,6 +2130,11 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-error-boundary@6.0.0:
+    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -4733,6 +4741,11 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-error-boundary@6.0.0(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.4
+      react: 19.1.0
 
   react-is@17.0.2: {}
 

--- a/src/config/QueryProvider.tsx
+++ b/src/config/QueryProvider.tsx
@@ -1,15 +1,15 @@
-import type { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import type { PropsWithChildren } from 'react';
 
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
       retry: false,
       staleTime: 1000 * 60 * 5,
     },
-    
+
     mutations: {
       retry: false,
     },

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -1,12 +1,11 @@
 import { BottomSheet, LoadingSpinner, TourCard } from '@/components';
 import { withGeoTripParams } from '@/pages/tour/components';
+import { useTourSwiperData } from '@/pages/tour/geotrip/service/useTourSwiperData';
 import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { Suspense, useMemo, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { Mousewheel, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperType } from 'swiper/types';
-import { getGeoLocationBasedTourQueryOptions } from '../../service';
 import { useStartTrip } from '../lib';
 import type { TourSummary } from '../types';
 import { TourOverView } from './';
@@ -22,15 +21,13 @@ function TourResultSwiper({
   distance,
   tourContentTypeId,
 }: TourResultSwiperProps) {
-  const { data, fetchNextPage, hasNextPage } = useSuspenseInfiniteQuery(
-    getGeoLocationBasedTourQueryOptions({
-      location,
-      radius: distance,
-      contentTypeId: tourContentTypeId,
-    }),
-  );
+  const { slides, fetchNextPage, hasNextPage } = useTourSwiperData({
+    location,
+    distance,
+    contentTypeId: tourContentTypeId,
+  });
   const [showDetail, setShowDetail] = useState(false);
-  const slides = useMemo(() => data.pages.flatMap(page => page.items), [data]);
+
   const [currentTourInfo, setCurrentTourInfo] = useState<TourSummary>({
     dist: slides[0].dist,
     title: slides[0].title,

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -1,12 +1,12 @@
 import { BottomSheet, LoadingSpinner, TourCard } from '@/components';
 import { withGeoTripParams } from '@/pages/tour/components';
-import { useTourSwiperData } from '@/pages/tour/geotrip/service/useTourSwiperData';
 import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
 import { Suspense, useState } from 'react';
-import { Mousewheel, Navigation, Pagination } from 'swiper/modules';
+import { Mousewheel, Navigation, Pagination, Virtual } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperType } from 'swiper/types';
 import { useStartTrip } from '../lib';
+import { useTourSwiperBasedData } from '../service';
 import type { TourSummary } from '../types';
 import { TourOverView } from './';
 import { SideButtonGroup } from './SideButtonGroup';
@@ -21,7 +21,7 @@ function TourResultSwiper({
   distance,
   tourContentTypeId,
 }: TourResultSwiperProps) {
-  const { slides, fetchNextPage, hasNextPage } = useTourSwiperData({
+  const { slides, fetchNextPage, hasNextPage } = useTourSwiperBasedData({
     location,
     distance,
     contentTypeId: tourContentTypeId,
@@ -31,11 +31,11 @@ function TourResultSwiper({
   const [currentTourInfo, setCurrentTourInfo] = useState<TourSummary>({
     dist: slides[0].dist,
     title: slides[0].title,
-    images: slides[0].images,
     contentid: slides[0].contentid,
     mapx: slides[0].mapx,
     mapy: slides[0].mapy,
     contenttypeid: slides[0].contenttypeid,
+    firstimage: slides[0].firstimage,
   });
 
   const handleSlideChange = (swiper: SwiperType) => {
@@ -44,7 +44,6 @@ function TourResultSwiper({
       setCurrentTourInfo({
         dist: current.dist,
         title: current.title,
-        images: current.images,
         contentid: current.contentid,
         mapx: current.mapx,
         mapy: current.mapy,
@@ -59,16 +58,17 @@ function TourResultSwiper({
     <>
       <Swiper
         direction="vertical"
-        modules={[Navigation, Pagination, Mousewheel]}
+        modules={[Navigation, Pagination, Mousewheel, Virtual]}
         pagination={false}
         mousewheel={{ enabled: true, sensitivity: 1 }}
         onReachEnd={() => hasNextPage && fetchNextPage()}
         className="h-full"
         touchMoveStopPropagation={false}
         onSlideChange={handleSlideChange}
+        virtual
       >
-        {slides.map(slide => (
-          <SwiperSlide key={slide.contentid}>
+        {slides.map((slide, index) => (
+          <SwiperSlide key={slide.contentid} virtualIndex={index}>
             <TourSlide
               tourInfo={slide}
               handleDetailOpen={() => setShowDetail(true)}
@@ -86,7 +86,7 @@ function TourResultSwiper({
           <TourCard
             title={currentTourInfo.title}
             distance={currentTourInfo.dist}
-            imgUrl={currentTourInfo.images[0].originimgurl || ''}
+            imgUrl={currentTourInfo.firstimage || ''}
             tourTypeId={currentTourInfo.contenttypeid}
           />
           <Suspense fallback={<LoadingSpinner />}>

--- a/src/pages/tour/geotrip/components/TourResultSwiper.tsx
+++ b/src/pages/tour/geotrip/components/TourResultSwiper.tsx
@@ -92,7 +92,7 @@ function TourResultSwiper({
           <Suspense fallback={<LoadingSpinner />}>
             <TourOverView contentId={currentTourInfo.contentid} />
           </Suspense>
-          <div className="mt-4  w-full flex items-center justify-center">
+          <div className="mt-4 w-full flex items-center justify-center">
             <button
               type="button"
               className="bg-gradient-to-r from-primary-orange to-primary-red rounded-[15px] w-[320px] h-[50px] text-black font-bold text-[16px] shadow-[0_4px_16px_0_rgba(250,129,47,0.3)]"

--- a/src/pages/tour/geotrip/components/TourSlide.tsx
+++ b/src/pages/tour/geotrip/components/TourSlide.tsx
@@ -1,13 +1,14 @@
 import { commonSVG } from '@/assets';
-import { DistanceTimeInfo } from '@/components';
+import { DistanceTimeInfo, LoadingSpinner } from '@/components';
 
-import type { TourItemWithDetailImages } from '@/pages/tour/types';
-import { Pagination } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import type { TourItem } from '@/pages/types';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { TourSlideImages } from '.';
 import { useStartTrip } from '../lib';
 
 interface TourSlideProps {
-  tourInfo: TourItemWithDetailImages;
+  tourInfo: TourItem;
   handleDetailOpen: () => void;
 }
 
@@ -19,29 +20,11 @@ export default function TourSlide({
 
   return (
     <article className="relative text-white w-full h-full flex flex-col items-center">
-      <Swiper
-        direction="horizontal"
-        modules={[Pagination]}
-        className="w-full h-full relative my-swiper"
-        pagination={{ clickable: true }}
-      >
-        {tourInfo.images.length === 0 ? (
-          <p className="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] z-(--z-layer5) text-black">
-            준비된 이미지가 없습니다.
-          </p>
-        ) : (
-          tourInfo.images.map(img => (
-            <SwiperSlide key={img.serialnum}>
-              <img
-                src={img.originimgurl || undefined}
-                alt={img.imgname}
-                className="w-full h-full object-cover"
-              />
-            </SwiperSlide>
-          ))
-        )}
-      </Swiper>
-
+      <ErrorBoundary FallbackComponent={() => <>임시 에러처리</>}>
+        <Suspense fallback={<LoadingSpinner />}>
+          <TourSlideImages contentId={tourInfo.contentid} />
+        </Suspense>
+      </ErrorBoundary>
       <footer className="w-full absolute z-(--z-layer2) bottom-0 left-0 px-4">
         <header>
           <div className="flex gap-1 items-center">

--- a/src/pages/tour/geotrip/components/TourSlide.tsx
+++ b/src/pages/tour/geotrip/components/TourSlide.tsx
@@ -31,8 +31,8 @@ export default function TourSlide({
           <TourSlideImages contentId={tourInfo.contentid} />
         </Suspense>
       </ErrorBoundary>
-      <footer className="w-full absolute z-(--z-layer2) bottom-0 left-0 px-4">
-        <header>
+      <footer className="w-full absolute z-[var(--z-layer2)] bottom-0 left-0 px-4 bg-gradient-to-t from-black/70 to-transparent max-h-60">
+        <div className="flex flex-col gap-2 py-4">
           <div className="flex gap-1 items-center">
             <h1 className="text-2xl font-bold max-w-60">{tourInfo.title}</h1>
             <commonSVG.InfoIcon
@@ -43,9 +43,8 @@ export default function TourSlide({
           <div className="flex justify-between">
             <DistanceTimeInfo dist={tourInfo.dist} iconFill="white" />
           </div>
-        </header>
-        <div className="mt-6" />
-        <nav className="w-full flex justify-center">
+        </div>
+        <nav className="w-full flex justify-center mt-4">
           <button
             type="button"
             className="mb-[24px] bg-white rounded-[15px] w-[320px] h-[50px] text-black font-bold text-[16px] cursor-pointer"

--- a/src/pages/tour/geotrip/components/TourSlide.tsx
+++ b/src/pages/tour/geotrip/components/TourSlide.tsx
@@ -1,12 +1,13 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Pagination } from 'swiper/modules';
-import type { TourItemWithDetail } from '@/pages/types';
 import { commonSVG } from '@/assets';
 import { DistanceTimeInfo } from '@/components';
+
+import type { TourItemWithDetailImages } from '@/pages/tour/types';
+import { Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
 import { useStartTrip } from '../lib';
 
 interface TourSlideProps {
-  tourInfo: TourItemWithDetail;
+  tourInfo: TourItemWithDetailImages;
   handleDetailOpen: () => void;
 }
 

--- a/src/pages/tour/geotrip/components/TourSlide.tsx
+++ b/src/pages/tour/geotrip/components/TourSlide.tsx
@@ -21,7 +21,13 @@ export default function TourSlide({
   return (
     <article className="relative text-white w-full h-full flex flex-col items-center">
       <ErrorBoundary FallbackComponent={() => <>임시 에러처리</>}>
-        <Suspense fallback={<LoadingSpinner />}>
+        <Suspense
+          fallback={
+            <div className="absolute w-full h-full flex ">
+              <LoadingSpinner />
+            </div>
+          }
+        >
           <TourSlideImages contentId={tourInfo.contentid} />
         </Suspense>
       </ErrorBoundary>

--- a/src/pages/tour/geotrip/components/TourSlide.tsx
+++ b/src/pages/tour/geotrip/components/TourSlide.tsx
@@ -20,7 +20,16 @@ export default function TourSlide({
 
   return (
     <article className="relative text-white w-full h-full flex flex-col items-center">
-      <ErrorBoundary FallbackComponent={() => <>임시 에러처리</>}>
+      <ErrorBoundary
+        fallback={
+          <img
+            src={tourInfo.firstimage}
+            alt={tourInfo.title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        }
+      >
         <Suspense
           fallback={
             <div className="absolute w-full h-full flex ">

--- a/src/pages/tour/geotrip/components/TourSlideImages.tsx
+++ b/src/pages/tour/geotrip/components/TourSlideImages.tsx
@@ -1,0 +1,32 @@
+import { tourQueries } from '@/pages/tour/service';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+interface TourSlideImagesProps {
+  contentId: string;
+}
+export default function TourSlideImages({ contentId }: TourSlideImagesProps) {
+  const { data: images } = useSuspenseQuery(
+    tourQueries.detailImages(contentId),
+  );
+
+  return (
+    <Swiper
+      direction="horizontal"
+      modules={[Pagination]}
+      className="w-full h-full relative my-swiper"
+      pagination={{ clickable: true }}
+    >
+      {images.map(img => (
+        <SwiperSlide key={img.serialnum}>
+          <img
+            src={img.originimgurl || undefined}
+            alt={img.imgname}
+            className="w-full h-full object-cover"
+          />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+}

--- a/src/pages/tour/geotrip/components/TourSlideImages.tsx
+++ b/src/pages/tour/geotrip/components/TourSlideImages.tsx
@@ -18,13 +18,13 @@ export default function TourSlideImages({ contentId }: TourSlideImagesProps) {
       className="w-full h-full relative my-swiper"
       pagination={{ clickable: true }}
     >
-      {images.map((img, index) => (
+      {images.map(img => (
         <SwiperSlide key={img.serialnum}>
           <img
             src={img.originimgurl || undefined}
             alt={img.imgname}
             className="w-full h-full object-cover"
-            loading={index === 0 ? 'eager' : 'lazy'}
+            loading="lazy"
           />
         </SwiperSlide>
       ))}

--- a/src/pages/tour/geotrip/components/TourSlideImages.tsx
+++ b/src/pages/tour/geotrip/components/TourSlideImages.tsx
@@ -18,12 +18,13 @@ export default function TourSlideImages({ contentId }: TourSlideImagesProps) {
       className="w-full h-full relative my-swiper"
       pagination={{ clickable: true }}
     >
-      {images.map(img => (
+      {images.map((img, index) => (
         <SwiperSlide key={img.serialnum}>
           <img
             src={img.originimgurl || undefined}
             alt={img.imgname}
             className="w-full h-full object-cover"
+            loading={index === 0 ? 'eager' : 'lazy'}
           />
         </SwiperSlide>
       ))}

--- a/src/pages/tour/geotrip/components/index.ts
+++ b/src/pages/tour/geotrip/components/index.ts
@@ -1,3 +1,4 @@
-export { default as TourSlide } from './TourSlide';
-export { default as TourResultSwiper } from './TourResultSwiper';
 export { default as TourOverView } from './TourOverView';
+export { default as TourResultSwiper } from './TourResultSwiper';
+export { default as TourSlide } from './TourSlide';
+export { default as TourSlideImages } from './TourSlideImages';

--- a/src/pages/tour/geotrip/service/index.ts
+++ b/src/pages/tour/geotrip/service/index.ts
@@ -1,1 +1,2 @@
 export { default as usePollySpeechMutation } from './pollyTTS';
+export { default as useTourSwiperBasedData } from './useTourSwiperBasedData';

--- a/src/pages/tour/geotrip/service/useTourSwiperBasedData.ts
+++ b/src/pages/tour/geotrip/service/useTourSwiperBasedData.ts
@@ -1,10 +1,10 @@
-import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
-import {
-  useSuspenseInfiniteQuery,
-  useSuspenseQuery,
-} from '@tanstack/react-query';
+import type {
+  AroundContentTypeId,
+  GeoTripLocation,
+  TourItem,
+} from '@/pages/types';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
-import type { TourItemWithDetailImages } from '@/pages/tour/types';
 import { useMemo } from 'react';
 import { tourQueries } from '../../service';
 
@@ -14,16 +14,16 @@ interface TourSwiperDataProps {
   contentTypeId: AroundContentTypeId;
 }
 interface TourSwiperDataReturn {
-  slides: TourItemWithDetailImages[];
+  slides: TourItem[];
   hasNextPage: boolean;
   fetchNextPage: () => void;
 }
 
-export function useTourSwiperData({
+const useTourSwiperBasedData = ({
   location,
   distance,
   contentTypeId,
-}: TourSwiperDataProps): TourSwiperDataReturn {
+}: TourSwiperDataProps): TourSwiperDataReturn => {
   const {
     data: basedItems,
     hasNextPage,
@@ -41,16 +41,7 @@ export function useTourSwiperData({
     [basedItems],
   );
 
-  const { data: images } = useSuspenseQuery(
-    tourQueries.detailImages(flatBasedItems[0].contentid),
-  );
+  return { slides: flatBasedItems, hasNextPage, fetchNextPage };
+};
 
-  const slides = flatBasedItems.map(item => {
-    return {
-      ...item,
-      images: images,
-    };
-  });
-
-  return { slides, hasNextPage, fetchNextPage };
-}
+export default useTourSwiperBasedData;

--- a/src/pages/tour/geotrip/service/useTourSwiperData.ts
+++ b/src/pages/tour/geotrip/service/useTourSwiperData.ts
@@ -1,0 +1,56 @@
+import type { AroundContentTypeId, GeoTripLocation } from '@/pages/types';
+import {
+  useSuspenseInfiniteQuery,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+
+import type { TourItemWithDetailImages } from '@/pages/tour/types';
+import { useMemo } from 'react';
+import { tourQueries } from '../../service';
+
+interface TourSwiperDataProps {
+  location: GeoTripLocation;
+  distance: string;
+  contentTypeId: AroundContentTypeId;
+}
+interface TourSwiperDataReturn {
+  slides: TourItemWithDetailImages[];
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+export function useTourSwiperData({
+  location,
+  distance,
+  contentTypeId,
+}: TourSwiperDataProps): TourSwiperDataReturn {
+  const {
+    data: basedItems,
+    hasNextPage,
+    fetchNextPage,
+  } = useSuspenseInfiniteQuery(
+    tourQueries.locationBasedList({
+      location,
+      radius: distance,
+      contentTypeId,
+    }),
+  );
+
+  const flatBasedItems = useMemo(
+    () => basedItems.pages.flatMap(page => page.items.item),
+    [basedItems],
+  );
+
+  const { data: images } = useSuspenseQuery(
+    tourQueries.detailImages(flatBasedItems[0].contentid),
+  );
+
+  const slides = flatBasedItems.map(item => {
+    return {
+      ...item,
+      images: images,
+    };
+  });
+
+  return { slides, hasNextPage, fetchNextPage };
+}

--- a/src/pages/tour/geotrip/types.d.ts
+++ b/src/pages/tour/geotrip/types.d.ts
@@ -1,6 +1,6 @@
-import type { TourItemWithDetail } from '@/pages/types';
+import type { TourItemWithDetailImages } from '@/pages/tour/types';
 
 export type TourSummary = Pick<
-  TourItemWithDetail,
+  TourItemWithDetailImages,
   'title' | 'dist' | 'mapx' | 'mapy' | 'contenttypeid' | 'images' | 'contentid'
 >;

--- a/src/pages/tour/geotrip/types.d.ts
+++ b/src/pages/tour/geotrip/types.d.ts
@@ -2,5 +2,11 @@ import type { TourItemWithDetailImages } from '@/pages/tour/types';
 
 export type TourSummary = Pick<
   TourItemWithDetailImages,
-  'title' | 'dist' | 'mapx' | 'mapy' | 'contenttypeid' | 'images' | 'contentid'
+  | 'title'
+  | 'dist'
+  | 'mapx'
+  | 'mapy'
+  | 'contenttypeid'
+  | 'contentid'
+  | 'firstimage'
 >;

--- a/src/pages/tour/service/getDetailImages.ts
+++ b/src/pages/tour/service/getDetailImages.ts
@@ -1,0 +1,18 @@
+import { tourApi } from '@/config/instance';
+import type { ApiResponse } from '@/pages/types';
+import type { TourDetailImage } from '../types';
+
+const getDetailImages = async (contentId: string) => {
+  const params = { contentId };
+  const imageRes = await tourApi.get<ApiResponse<TourDetailImage[]>>(
+    `/detailImage2`,
+    { params },
+  );
+  if (!imageRes.data.response.body.items.item) {
+    throw new Error(`no images`);
+  }
+
+  return imageRes.data.response.body.items.item;
+};
+
+export default getDetailImages;

--- a/src/pages/tour/service/index.ts
+++ b/src/pages/tour/service/index.ts
@@ -1,2 +1,4 @@
-export { default as getGeoLocationBasedTourQueryOptions } from './getLocationBasedData';
+export { default as getDetailImages } from './getDetailImages';
+export { default as getLocationBasedItems } from './getLocationBasedData';
 export { default as getTourDetailQueryOptions } from './getTourDetail';
+export { default as tourQueries } from './queryOptions';

--- a/src/pages/tour/service/queryOptions.ts
+++ b/src/pages/tour/service/queryOptions.ts
@@ -1,0 +1,34 @@
+import type { ResponseBody, TourItem } from '@/pages/types';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
+import type { LocationBasedItemRequest } from '../types';
+import { getDetailImages, getLocationBasedItems } from './';
+
+const tourQueries = {
+  locationBasedLists: () => ['locationBasedData'] as const,
+  locationBasedList: (request: Omit<LocationBasedItemRequest, 'pageNo'>) =>
+    infiniteQueryOptions({
+      queryKey: [...tourQueries.locationBasedLists(), request],
+      initialPageParam: 1,
+      queryFn: ({ pageParam }: { pageParam: number }) =>
+        getLocationBasedItems({
+          location: request.location,
+          pageNo: pageParam,
+          contentTypeId: request.contentTypeId,
+          radius: request.radius,
+        }),
+      getNextPageParam: (lastPage: ResponseBody<TourItem[]>) => {
+        const currentPage = lastPage.pageNo;
+        const totalPage = Math.ceil(lastPage.totalCount / lastPage.numOfRows);
+        return currentPage < totalPage ? currentPage + 1 : undefined;
+      },
+    }),
+  detail: (contentId: string) =>
+    [...tourQueries.locationBasedLists(), 'detail', contentId] as const,
+  detailImages: (contentId: string) =>
+    queryOptions({
+      queryKey: [...tourQueries.detail(contentId), 'images'],
+      queryFn: () => getDetailImages(contentId),
+    }),
+};
+
+export default tourQueries;

--- a/src/pages/tour/tourList/components/TourCardImages.tsx
+++ b/src/pages/tour/tourList/components/TourCardImages.tsx
@@ -1,0 +1,45 @@
+import { tourQueries } from '@/pages/tour/service';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+interface TourCardImagesProps {
+  contentId: string;
+  title: string;
+}
+export default function TourCardImages({
+  contentId,
+  title,
+}: TourCardImagesProps) {
+  const { data: images } = useSuspenseQuery(
+    tourQueries.detailImages(contentId),
+  );
+
+  return (
+    <figure className="w-full h-[150px]">
+      <div className="flex gap-0.5 h-full flex-6/10">
+        <div className="relative">
+          <img
+            src={images[0].originimgurl}
+            className="h-full object-cover aspect-square rounded"
+            alt={title}
+          />
+        </div>
+        <div className="flex flex-col gap-0.5 h-full flex-4/10">
+          <div className="relative h-1/2">
+            <img
+              src={images[0].originimgurl}
+              className="object-cover h-full w-full"
+              alt={`${title} 썸네일 1`}
+            />
+          </div>
+          <div className="relative h-1/2">
+            <img
+              src={images[0].originimgurl}
+              className="object-cover h-full w-full"
+              alt={`${title} 썸네일 2`}
+            />
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+}

--- a/src/pages/tour/tourList/components/TourInfoCard.tsx
+++ b/src/pages/tour/tourList/components/TourInfoCard.tsx
@@ -3,8 +3,9 @@ import { DistanceTimeInfo } from '@/components';
 import { truncate } from '@/lib';
 import { TOUR_TYPE } from '@/pages/const/MARKER';
 import type { TourItem } from '@/pages/types';
-import { TourCardImages } from './';
-
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { SkeletonCard, TourCardImages } from './';
 interface TourInfoCardProps {
   tourInfo: TourItem;
 }
@@ -12,7 +13,14 @@ interface TourInfoCardProps {
 export default function TourInfoCard({ tourInfo }: TourInfoCardProps) {
   return (
     <article className="flex flex-col my-8">
-      <TourCardImages contentId={tourInfo.contentid} title={tourInfo.title} />
+      <ErrorBoundary FallbackComponent={() => <>임시 에러처리</>}>
+        <Suspense fallback={<SkeletonCard />}>
+          <TourCardImages
+            contentId={tourInfo.contentid}
+            title={tourInfo.title}
+          />
+        </Suspense>
+      </ErrorBoundary>
 
       {/* 타이틀 및 옵션 */}
       <header className="flex mt-4 items-center justify-between px-5">

--- a/src/pages/tour/tourList/components/TourInfoCard.tsx
+++ b/src/pages/tour/tourList/components/TourInfoCard.tsx
@@ -2,44 +2,17 @@ import { commonSVG } from '@/assets';
 import { DistanceTimeInfo } from '@/components';
 import { truncate } from '@/lib';
 import { TOUR_TYPE } from '@/pages/const/MARKER';
-
-import type { TourItemWithDetail } from '@/pages/types';
+import type { TourItem } from '@/pages/types';
+import { TourCardImages } from './';
 
 interface TourInfoCardProps {
-  tourInfo: TourItemWithDetail;
+  tourInfo: TourItem;
 }
 
 export default function TourInfoCard({ tourInfo }: TourInfoCardProps) {
   return (
     <article className="flex flex-col my-8">
-      {/* 이미지 섹션 */}
-      <figure className="w-full h-[150px]">
-        <div className="flex gap-0.5 h-full flex-6/10">
-          <div className="relative">
-            <img
-              src={tourInfo.images[0].originimgurl}
-              className="h-full object-cover aspect-square rounded"
-              alt={tourInfo.title}
-            />
-          </div>
-          <div className="flex flex-col gap-0.5 h-full flex-4/10">
-            <div className="relative h-1/2">
-              <img
-                src={tourInfo.images[0].originimgurl}
-                className="object-cover h-full w-full"
-                alt={`${tourInfo.title} 썸네일 1`}
-              />
-            </div>
-            <div className="relative h-1/2">
-              <img
-                src={tourInfo.images[0].originimgurl}
-                className="object-cover h-full w-full"
-                alt={`${tourInfo.title} 썸네일 2`}
-              />
-            </div>
-          </div>
-        </div>
-      </figure>
+      <TourCardImages contentId={tourInfo.contentid} title={tourInfo.title} />
 
       {/* 타이틀 및 옵션 */}
       <header className="flex mt-4 items-center justify-between px-5">

--- a/src/pages/tour/tourList/components/index.ts
+++ b/src/pages/tour/tourList/components/index.ts
@@ -1,5 +1,6 @@
-export { default as TourInfoCard } from './TourInfoCard';
-export { default as TourListContainer } from './TourListContainer';
-export { default as SkeletonCard } from './SkeletonCard';
 export { default as InfiniteScroll } from './InfiniteScroll';
+export { default as SkeletonCard } from './SkeletonCard';
+export { default as TourCardImages } from './TourCardImages';
+export { default as TourInfoCard } from './TourInfoCard';
 export { default as TouristFilterQueryUpdater } from './TouristFilterQueryUpdater';
+export { default as TourListContainer } from './TourListContainer';

--- a/src/pages/tour/types.d.ts
+++ b/src/pages/tour/types.d.ts
@@ -1,0 +1,17 @@
+import { TourItem } from '@/pages/types';
+
+export type LocationBasedItemRequest = {
+  location: GeoTripLocation | null;
+  pageNo: number;
+  contentTypeId: AroundContentTypeId;
+  radius: string;
+};
+export type TourDetailImage = {
+  imgname?: string;
+  originimgurl?: string;
+  serialnum: string;
+};
+
+export type TourItemWithDetailImages = TourItem & {
+  images: TourDetailImage[];
+};

--- a/src/pages/types.d.ts
+++ b/src/pages/types.d.ts
@@ -50,21 +50,6 @@ export type TourItem = {
   zipcode?: string;
 };
 
-export type TourDetailImage = {
-  imgname?: string;
-  originimgurl?: string;
-  serialnum: string;
-};
-
-export type TourDetailResponse = {
-  overview: string;
-  images?: TourDetailImage[];
-};
-
-export type TourItemWithDetail = TourItem & {
-  images: TourDetailImage[];
-};
-
 export type AroundContentTypeId =
   | '' // 없음
   | '12' // 관광지


### PR DESCRIPTION
## 🔗 관련 이슈
#69 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용

### 리팩토링 이전
<img width="810" height="535" alt="image" src="https://github.com/user-attachments/assets/4f3d0f13-5919-4c75-94a2-dbf69ecd1b3c" />
<img width="813" height="538" alt="image" src="https://github.com/user-attachments/assets/89fec9a1-0bff-4334-9bd8-a8847efacbc1" />



### 리팩토링 이후
<img width="816" height="853" alt="image" src="https://github.com/user-attachments/assets/92b58b0d-fb47-45c2-8d90-746712a72f8f" />
<img width="814" height="856" alt="image" src="https://github.com/user-attachments/assets/292866c0-8c6f-4628-839d-8de05204242e" />


## 결론

### open api 요청 갯수
기존: 10개 이상
리팩토링 이후: 베이스 요청, 현재, 다음 페이지(preFetch) -> 3개로 감소

### 초기 로딩
베이스 요청 -> 디테일 이미지 요청 워터풀 로딩 측정

기존: 약 2-4초 이상 소요
리팩토링 후: 약 1-2 초
약 2배 감소

### 이미지 요청 감소 + lazy 로딩
기존: 초기 이미지 수 38개 이상 용량 13,530kb
리팩토링 후: 초기 이미지 수 약 8개 용량 753kb로 감소





<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)

