### PR TITLE
숏폼 특정 타입 무한랜더링 버그수정

### DIFF
--- a/src/features/tour/hook/useInfiniteSwiperControl.ts
+++ b/src/features/tour/hook/useInfiniteSwiperControl.ts
@@ -35,13 +35,12 @@ export const useInfiniteSwiperControl = ({
     const prependLength = result?.data?.pages[0]?.items.item.length ?? 0;
 
     const targetIndex = currentIndex + prependLength;
-
     const handleSlidesUpdated = () => {
       swiper.slideTo(targetIndex, 0);
       swiper.off('slidesUpdated', handleSlidesUpdated);
-      setIsInitializing(false);
     };
 
+    setIsInitializing(false);
     swiper.on('slidesUpdated', handleSlidesUpdated);
   };
 

--- a/src/features/tour/hook/useInfiniteSwiperControl.ts
+++ b/src/features/tour/hook/useInfiniteSwiperControl.ts
@@ -3,7 +3,7 @@ import type {
   InfiniteData,
   InfiniteQueryObserverResult,
 } from '@tanstack/react-query';
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { Swiper as SwiperType } from 'swiper/types';
 
 type PageFetchQuery = () =>
@@ -29,20 +29,17 @@ export const useInfiniteSwiperControl = ({
   const swiperRef = useRef<SwiperType | null>(null);
   const onSwiper = async (swiper: SwiperType) => {
     swiperRef.current = swiper;
+  };
 
+  const handleSlideTo = useCallback(async () => {
     const currentIndex = Number(sessionStorage.getItem('currentIndex') ?? 0);
     const result = await fetchPrepend();
     const prependLength = result?.data?.pages[0]?.items.item.length ?? 0;
 
     const targetIndex = currentIndex + prependLength;
-    const handleSlidesUpdated = () => {
-      swiper.slideTo(targetIndex, 0);
-      swiper.off('slidesUpdated', handleSlidesUpdated);
-    };
-
+    swiperRef.current?.slideTo(targetIndex, 0);
     setIsInitializing(false);
-    swiper.on('slidesUpdated', handleSlidesUpdated);
-  };
+  }, []);
 
   const handleAppend = async () => {
     await fetchAppend();
@@ -62,5 +59,6 @@ export const useInfiniteSwiperControl = ({
     onSwiper,
     handlePrepend,
     handleAppend,
+    handleSlideTo,
   };
 };

--- a/src/features/tourShort/ui/TourSwiperContainer.tsx
+++ b/src/features/tourShort/ui/TourSwiperContainer.tsx
@@ -31,11 +31,17 @@ function TourSwiperContainer({
       radius: distance,
       contentTypeId: tourContentTypeId,
     });
-  const { swiperRef, onSwiper, handlePrepend, handleAppend, isInitializing } =
-    useInfiniteSwiperControl({
-      fetchPrepend,
-      fetchAppend,
-    });
+  const {
+    swiperRef,
+    onSwiper,
+    handlePrepend,
+    handleAppend,
+    isInitializing,
+    handleSlideTo,
+  } = useInfiniteSwiperControl({
+    fetchPrepend,
+    fetchAppend,
+  });
 
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
@@ -55,11 +61,11 @@ function TourSwiperContainer({
         isInitializing={isInitializing}
         isFetchingPreviousPage={isFetchingPreviousPage}
       />
-
       <TourSwiperView
         handleAppend={handleAppend}
         handlePrepend={handlePrepend}
         handleSlideChange={handleSlideChange}
+        handleSlideTo={handleSlideTo}
         onSwiper={onSwiper}
         slideEntries={slideEntries}
         openBottomSheet={() => setIsBottomSheetOpen(true)}

--- a/src/features/tourShort/ui/TourSwiperView.tsx
+++ b/src/features/tourShort/ui/TourSwiperView.tsx
@@ -31,6 +31,7 @@ export default function TourSwiperView({
       ? 'opacity-0 pointer-events-none'
       : 'h-full transition-opacity duration-300',
   );
+
   return (
     <Swiper
       direction="vertical"

--- a/src/features/tourShort/ui/TourSwiperView.tsx
+++ b/src/features/tourShort/ui/TourSwiperView.tsx
@@ -6,6 +6,7 @@ import { TourSlide } from '@/features/tourShort';
 
 import type { Swiper as SwiperType } from 'swiper/types';
 import type { SlideEntries } from '@/features/tour/types';
+import { useLayoutEffect } from 'react';
 
 interface TourSwiperViewProps {
   onSwiper: (swiper: SwiperType) => Promise<void>;
@@ -14,6 +15,7 @@ interface TourSwiperViewProps {
   handlePrepend: () => Promise<void>;
   slideEntries: SlideEntries[];
   openBottomSheet: () => void;
+  handleSlideTo: () => Promise<void>;
   isInitializing: boolean;
 }
 
@@ -25,7 +27,12 @@ export default function TourSwiperView({
   openBottomSheet,
   slideEntries,
   isInitializing,
+  handleSlideTo,
 }: TourSwiperViewProps) {
+  useLayoutEffect(() => {
+    handleSlideTo();
+  }, []);
+
   const className = clsx(
     isInitializing
       ? 'opacity-0 pointer-events-none'


### PR DESCRIPTION
## 🔗 관련 이슈
#120 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용

### 버그 내용
숙박, 음식점 등 특정 관광타입을 누른 경우 무한 로딩이 걸리는 버그를 수정했습니다.

### 이슈 내용
```ts
  const handleSlidesUpdated = () => {
      swiper.slideTo(targetIndex, 0);
      swiper.off('slidesUpdated', handleSlidesUpdated);
      setIsInitializing(false);
    };

    swiper.on('slidesUpdated', handleSlidesUpdated);
```
기존 `swiper js`의 `slidesUpdated` 이벤트에 `slideTo`함수를 사용하여 슬라이드 위치를 복구했습니다.(랜더링 후 접근을 위한 이벤트)
그러나 해당 이벤트는 슬라이드가 업데이트될때 발생하는 이벤트라 내부에 `images` 가 없을때는 슬라이드가 리랜더링(업데이트) 되지 않아 해당 이벤트가 발생하지 않아 `initializing` 상태가 계속 `true`여서 무한 로딩이 발생하였습니다.

### 해결 방법
`swiper js`에서 swiper의 내부 요소가 전부 랜더링 된 후 콜백을 실행하는 이벤트는 없기에
`React`의 `useLayoutEffect `를 사용하여 랜더링 후 안전하게 DOM에 접근하여 slide를 이동시켰습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
