### PR TITLE
이미지 요청 수정

### DIFF
--- a/src/features/tourShort/lib/convertHttpToHttps.ts
+++ b/src/features/tourShort/lib/convertHttpToHttps.ts
@@ -1,0 +1,11 @@
+export const convertHttpToHttps = (url: string | undefined | null): string => {
+  if (!url || typeof url !== 'string') {
+    return '/common/fallback.webp';
+  }
+
+  if (url.startsWith('http://')) {
+    return url.replace('http://', 'https://');
+  }
+
+  return url;
+};

--- a/src/features/tourShort/lib/index.ts
+++ b/src/features/tourShort/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './convertHttpToHttps';

--- a/src/features/tourShort/ui/TourSlide.tsx
+++ b/src/features/tourShort/ui/TourSlide.tsx
@@ -31,17 +31,9 @@ export default function TourSlide({
       >
         <Suspense
           fallback={
-            <>
-              <img
-                src={tourInfo.firstimage}
-                alt={tourInfo.title}
-                className="w-full h-full object-cover"
-                loading="lazy"
-              />
-              <div className="absolute w-full h-full flex ">
-                <LoadingSpinner />
-              </div>
-            </>
+            <div className="absolute w-full h-full flex justify-center items-center">
+              <LoadingSpinner />
+            </div>
           }
         >
           <TourSlideImages contentId={tourInfo.contentid} />

--- a/src/features/tourShort/ui/TourSlideImages.tsx
+++ b/src/features/tourShort/ui/TourSlideImages.tsx
@@ -19,13 +19,13 @@ export default function TourSlideImages({ contentId }: TourSlideImagesProps) {
       className="w-full h-full relative my-swiper"
       pagination={{ clickable: true }}
     >
-      {images.map(img => (
+      {images.map((img, index) => (
         <SwiperSlide key={img.serialnum}>
           <img
             src={img.originimgurl || undefined}
             alt={img.imgname}
             className="w-full h-full object-cover"
-            loading="lazy"
+            loading={index === 0 ? 'eager' : 'lazy'}
           />
         </SwiperSlide>
       ))}

--- a/src/features/tourShort/ui/TourSlideImages.tsx
+++ b/src/features/tourShort/ui/TourSlideImages.tsx
@@ -2,6 +2,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Pagination } from 'swiper/modules';
 
+import { convertHttpToHttps } from '@/features/tourShort';
 import { tourQueries } from '@/entities/tour';
 
 interface TourSlideImagesProps {
@@ -22,7 +23,7 @@ export default function TourSlideImages({ contentId }: TourSlideImagesProps) {
       {images.map((img, index) => (
         <SwiperSlide key={img.serialnum}>
           <img
-            src={img.originimgurl || undefined}
+            src={convertHttpToHttps(img.originimgurl) || undefined}
             alt={img.imgname}
             className="w-full h-full object-cover"
             loading={index === 0 ? 'eager' : 'lazy'}


### PR DESCRIPTION
## 🔗 관련 이슈
#158
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
### 1. 이미지 fallback 수정
<img width="189" height="471" alt="image" src="https://github.com/user-attachments/assets/0475f8d8-29bc-49eb-bbd9-aaa3c1064ac4" />
이미지 로딩스피너가 가운데 뜨도록 수정했습니다.

### 2. image 바뀜 수정
기존 로딩전에 이미지가 갑자기 바뀌는걸 수정했습니다.

## 3, 이미지 https로 요청
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
