### PR TITLE
[#191] 지도 lazy적용

### DIFF
--- a/src/features/navigate/lib/useDestination.ts
+++ b/src/features/navigate/lib/useDestination.ts
@@ -1,0 +1,41 @@
+import { useStore } from 'zustand';
+import {
+  useFollowAlongStore,
+  useMapLevelStore,
+  useTransportationStore,
+} from '.';
+import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { getSuspenseLocation } from '@/shared';
+import type { TransportationType } from '@/entities/navigate';
+
+const useDestination = () => {
+  const [searchParams] = useSearchParams();
+
+  const { reset: resetFollowAlong } = useStore(useFollowAlongStore);
+  const { reset: resetTransportation, setVehicle } = useStore(
+    useTransportationStore,
+  );
+  const { reset: resetMapLevel } = useStore(useMapLevelStore);
+
+  //이동수단
+  const vehicle = searchParams.get('vehicle');
+
+  useEffect(() => {
+    setVehicle(vehicle as TransportationType);
+  }, [vehicle]);
+
+  const geoLocation = getSuspenseLocation();
+
+  useEffect(() => {
+    return () => {
+      resetTransportation();
+      resetMapLevel();
+      resetFollowAlong();
+    };
+  }, [resetFollowAlong, resetTransportation, resetMapLevel]);
+
+  return { geoLocation };
+};
+
+export default useDestination;

--- a/src/features/navigate/lib/useGettingLocation.ts
+++ b/src/features/navigate/lib/useGettingLocation.ts
@@ -1,0 +1,18 @@
+import { useSearchParams } from 'react-router-dom';
+
+const useGettingLocation = () => {
+  const [searchParams] = useSearchParams();
+
+  //좌표
+  const lng = searchParams.get('lnt');
+  const lat = searchParams.get('lat');
+
+  const destination = {
+    lng: lng ? parseFloat(lng) : 0,
+    lat: lat ? parseFloat(lat) : 0,
+  };
+
+  return { destination };
+};
+
+export default useGettingLocation;

--- a/src/features/navigate/lib/withDestination.tsx
+++ b/src/features/navigate/lib/withDestination.tsx
@@ -1,24 +1,19 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { useStore } from 'zustand';
 import { useSearchParams } from 'react-router-dom';
 
 import {
   useFollowAlongStore,
-  useMapLevelStore,
-  useTransportationStore,
   SelectTransportationFromGeoMap,
   isValidationLocation,
   DepartureAndArrivalAddress,
   DestinationSkeleton,
 } from '@/features/navigate';
-import {
-  getSuspenseLocation,
-  LoadingSpinner,
-  QueryErrorBoundary,
-} from '@/shared';
+import { LoadingSpinner, QueryErrorBoundary } from '@/shared';
 
 import type { GeoTripLocation } from '@/shared';
-import type { TransportationType } from '@/entities/navigate';
+import useGettingLocation from './useGettingLocation';
+import useDestination from './useDestination';
 
 interface WithDestinationProps {
   start: GeoTripLocation;
@@ -31,42 +26,12 @@ export default function withDestination<P extends WithDestinationProps>(
   return function GeoDestinationMapWrapper(
     props: Omit<P, keyof WithDestinationProps>,
   ) {
-    const { isFollowAlong, reset: resetFollowAlong } =
-      useStore(useFollowAlongStore);
-    const { reset: resetTransportation, setVehicle } = useStore(
-      useTransportationStore,
-    );
-    const { reset: resetMapLevel } = useStore(useMapLevelStore);
+    const { isFollowAlong } = useStore(useFollowAlongStore);
+    const { geoLocation } = useDestination();
+    const { destination } = useGettingLocation();
     const [searchParams] = useSearchParams();
 
-    //좌표
-    const lng = searchParams.get('lnt');
-    const lat = searchParams.get('lat');
-
-    const destination = {
-      lng: lng ? parseFloat(lng) : 0,
-      lat: lat ? parseFloat(lat) : 0,
-    };
-
-    //컨텐츠 ID, Type
     const id = searchParams.get('id') && atob(searchParams.get('id') as string);
-
-    //이동수단
-    const vehicle = searchParams.get('vehicle');
-
-    useEffect(() => {
-      setVehicle(vehicle as TransportationType);
-    }, [vehicle]);
-
-    const geoLocation = getSuspenseLocation();
-
-    useEffect(() => {
-      return () => {
-        resetTransportation();
-        resetMapLevel();
-        resetFollowAlong();
-      };
-    }, [resetFollowAlong, resetTransportation, resetMapLevel]);
 
     if (
       !isValidationLocation(geoLocation) ||
@@ -88,13 +53,15 @@ export default function withDestination<P extends WithDestinationProps>(
             <SelectTransportationFromGeoMap />
           </div>
         )}
-        <Suspense fallback={<LoadingSpinner centered={true} />}>
-          <WrappedComponent
-            {...(props as P)}
-            start={geoLocation}
-            end={destination}
-          />
-        </Suspense>
+        <QueryErrorBoundary>
+          <Suspense fallback={<LoadingSpinner centered={true} />}>
+            <WrappedComponent
+              {...(props as P)}
+              start={geoLocation}
+              end={destination}
+            />
+          </Suspense>
+        </QueryErrorBoundary>
       </>
     );
   };

--- a/src/features/navigate/ui/GeoDestinationMap.tsx
+++ b/src/features/navigate/ui/GeoDestinationMap.tsx
@@ -5,17 +5,21 @@ import {
   useTransportationStore,
   withDestination,
 } from '@/features/navigate';
-import { Car } from '@/features/car';
-import { Pedestrian } from '@/features/pedestrian';
-import { PublicTransit } from '@/features/publicTransit';
 import { LoadingSpinner } from '@/shared';
 
 import type { GeoTripLocation } from '@/shared';
+import { lazy } from 'react';
 
 interface GeoDestinationMapProps {
   start: GeoTripLocation;
   end: GeoTripLocation;
 }
+
+const Pedestrian = lazy(() => import('@/features/pedestrian/ui/Pedestrian'));
+const Car = lazy(() => import('@/features/car/ui/Car'));
+const PublicTransit = lazy(
+  () => import('@/features/publicTransit/ui/PublicTransit'),
+);
 
 function GeoDestinationMap({ start, end }: GeoDestinationMapProps) {
   const { vehicle } = useStore(useTransportationStore);


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->
#191

## 📝작업 내용

- 지도 각 컴포넌트에 맞게 lazy적용
- 고차 컴포넌트에서 불러오는 로직 분리
    - `useDestination`: destination관련 정보를 불러오는 hook
    -  `useGettingLocation`: `destionation의 위치 정보를 불러오는 hook
    - `id`는 그냥 `withDestintaion`에서 불러옴

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
